### PR TITLE
Add native module for linux-aarch64

### DIFF
--- a/brotli4j/pom.xml
+++ b/brotli4j/pom.xml
@@ -47,6 +47,23 @@
             </dependencies>
         </profile>
 
+        <profile>
+            <id>linux-aarch64</id>
+            <activation>
+                <os>
+                    <family>linux</family>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.aayushatharva.brotli4j</groupId>
+                    <artifactId>native-linux-aarch64</artifactId>
+                    <version>1.3.0</version>
+                </dependency>
+            </dependencies>
+        </profile>
+
 	    <profile>
             <id>windows-x86_64</id>
             <activation>

--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/Brotli4jLoader.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/Brotli4jLoader.java
@@ -89,6 +89,8 @@ public class Brotli4jLoader {
         if (osName.equalsIgnoreCase("Linux")) {
             if (archName.equalsIgnoreCase("amd64")) {
                 return "linux-x86_64";
+            } else if (archName.equalsIgnoreCase("aarch64")) {
+                return "linux-aarch64";
             }
         } else if (osName.startsWith("Windows")) {
             if (archName.equalsIgnoreCase("amd64")) {

--- a/natives/linux-aarch64/build.sh
+++ b/natives/linux-aarch64/build.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+CURPATH=$(pwd)
+TARGET_CLASSES_PATH="target/classes/lib/linux-aarch64"
+TARGET_PATH="target"
+
+exitWithError() {
+  cd ${CURPATH}
+  echo "*** An error occurred. Please check log messages. ***"
+  exit $1
+}
+
+mkdir -p "$TARGET_CLASSES_PATH"
+
+cd "$TARGET_PATH"
+cmake ../../../ || exitWithError $?
+make || exitWithError $?
+rm -f "$CURPATH/${TARGET_CLASSES_PATH}/libbrotli.so"
+cp "./libbrotli.so" "$CURPATH/${TARGET_CLASSES_PATH}" || exitWithError $?
+
+cd "${CURPATH}"

--- a/natives/linux-aarch64/pom.xml
+++ b/natives/linux-aarch64/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2021, Aayush Atharva
+
+  Brotli4j licenses this file to you under the
+  Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>natives</artifactId>
+        <groupId>com.aayushatharva.brotli4j</groupId>
+        <version>1.3.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>native-linux-aarch64</artifactId>
+    <packaging>jar</packaging>
+
+    <profiles>
+        <profile>
+            <id>linux-aarch64</id>
+            <activation>
+                <os>
+                    <family>linux</family>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <executions>
+                            <execution>
+                                <id>build-native</id>
+                                <phase>process-classes</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>/bin/bash</executable>
+                                    <arguments>
+                                        <argument>build.sh</argument>
+                                    </arguments>
+                                    <workingDirectory>${project.basedir}</workingDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>release</id>
+            <build>
+                <resources>
+                    <resource>
+                        <directory>resources</directory>
+                    </resource>
+                </resources>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/natives/pom.xml
+++ b/natives/pom.xml
@@ -29,7 +29,8 @@ Copyright 2021, Aayush Atharva
     <packaging>pom</packaging>
     <modules>
         <module>linux-x86_64</module>
-	    <module>windows-x86_64</module>
+        <module>linux-aarch64</module>
+        <module>windows-x86_64</module>
         <module>osx-x86_64</module>
     </modules>
 
@@ -44,6 +45,19 @@ Copyright 2021, Aayush Atharva
             </activation>
             <modules>
                 <module>linux-x86_64</module>
+            </modules>
+        </profile>
+
+        <profile>
+            <id>linux-aarch64</id>
+            <activation>
+                <os>
+                    <family>Linux</family>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <modules>
+                <module>linux-aarch64</module>
             </modules>
         </profile>
 
@@ -77,7 +91,8 @@ Copyright 2021, Aayush Atharva
             <id>release</id>
             <modules>
                 <module>linux-x86_64</module>
-		        <module>windows-x86_64</module>
+                <module>linux-aarch64</module>
+                <module>windows-x86_64</module>
                 <module>osx-x86_64</module>
             </modules>
         </profile>


### PR DESCRIPTION
[native-linux-aarch64.tgz.txt](https://github.com/hyperxpro/Brotli4j/files/5951801/native-linux-aarch64.tgz.txt)

Here is a TGZ file of /home/ubuntu/.m2/repository/com/aayushatharva/brotli4j/native-linux-aarch64/. Just remove `.txt` extension (GitHub does not allow `.tgz` attachments).

