### PR TITLE
Do not require the caller to try/catch Throwable

### DIFF
--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/Brotli4jLoader.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/Brotli4jLoader.java
@@ -71,11 +71,13 @@ public class Brotli4jLoader {
     /**
      * Ensure Brotli native library is available.
      *
-     * @throws Throwable {@link UnsatisfiedLinkError} If unavailable.
+     * @throws UnsatisfiedLinkError If unavailable.
      */
-    public static void ensureAvailability() throws Throwable {
+    public static void ensureAvailability() {
         if (UNAVAILABILITY_CAUSE != null) {
-            throw new UnsatisfiedLinkError("Failed to load Brotli native library").initCause(UNAVAILABILITY_CAUSE);
+            UnsatisfiedLinkError error = new UnsatisfiedLinkError("Failed to load Brotli native library");
+            error.initCause(UNAVAILABILITY_CAUSE);
+            throw error;
         }
     }
 


### PR DESCRIPTION
Return UnsatisfiedLinkError instead the result of #initCause(), i.e. a Throwable.
This way there is no need to declare 'throws' or try/catch at the caller site