### PR TITLE
fix CMakefile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,6 @@ if (JNI_FOUND)
     message (STATUS "JNI_LIBRARIES=${JNI_LIBRARIES}")
 endif()
 include_directories(${JNI_INCLUDE_DIRS})
-include_directories(${JNI_LIBRARIES})
 
 SET (BROTLI_INCLUDE_DIRS "brotli/include" "brotli/common")
 include_directories(${BROTLI_INCLUDE_DIRS})
@@ -18,6 +17,9 @@ include_directories(${BROTLI_INCLUDE_DIRS})
 SET (LIB_TYPE SHARED)
 SET (CMAKE_JNI_TARGET TRUE)
 SET (CMAKE_CXX_FLAGS "-Wall -O3")
+
+SET (CMAKE_CXX_STANDARD 11)
+SET (CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(WIN32)
     SET(STATIC_LIBRARY_CXX_FLAGS /MD)

--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -1,4 +1,6 @@
-FROM gatlingcorp/centos:6-gcc7
+FROM gatlingcorp/centos:6-gcc5
+
+RUN rm -vf /usr/lib64/libstdc++.so.6.0.24-gdb.py
 
 RUN yum -y install \
             git 


### PR DESCRIPTION

fix for build on centos6
 - cmake directive
 - change compiler to gcc5 to match the right ABI
 