### PR TITLE
Provide a decompress method which limits the size of the output buffe…

### DIFF
--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/decoder/Decoder.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/decoder/Decoder.java
@@ -24,7 +24,6 @@ package com.aayushatharva.brotli4j.decoder;
 
 import com.aayushatharva.brotli4j.common.annotations.Local;
 import com.aayushatharva.brotli4j.common.annotations.Upstream;
-import io.netty.buffer.ByteBuf;
 
 import java.io.IOException;
 import java.nio.Buffer;
@@ -159,12 +158,12 @@ public class Decoder {
                     decoder.push(0);
                     // If decoder still needs more, input buffer was incomplete.
                     if (decoder.getStatus() == DecoderJNI.Status.NEEDS_MORE_INPUT) {
-                        return new DirectDecompress(decoder.getStatus(), null);
+                        return new DirectDecompress(decoder.getStatus(), null, null);
                     }
                     break;
 
                 default:
-                    return new DirectDecompress(decoder.getStatus(), null);
+                    return new DirectDecompress(decoder.getStatus(), null, null);
                 }
             }
         } finally {
@@ -173,7 +172,7 @@ public class Decoder {
         if (outputRead < decompressedLength) {
             throw new IllegalArgumentException("Output length has less than expected length");
         }
-        return new DirectDecompress(decoder.getStatus(), output);
+        return new DirectDecompress(decoder.getStatus(), output, null);
     }
 
     private void fail(String message) throws IOException {

--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/decoder/Decoder.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/decoder/Decoder.java
@@ -150,7 +150,7 @@ public class Decoder {
                     buffer.get(output, outputRead, readLen);
                     outputRead += readLen;
                     if (buffer.remaining() > 0 && outputRead == decompressedLength) {
-                        throw new IllegalArgumentException("Output length exceeded expected.");
+                        throw new IllegalArgumentException("Output length has exceeded expected length");
                     }
                     break;
 
@@ -171,7 +171,7 @@ public class Decoder {
             decoder.destroy();
         }
         if (outputRead < decompressedLength) {
-            throw new IllegalArgumentException("Output length less than expected.");
+            throw new IllegalArgumentException("Output length has less than expected length");
         }
         return new DirectDecompress(decoder.getStatus(), output);
     }

--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/decoder/DecoderJNI.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/decoder/DecoderJNI.java
@@ -36,7 +36,7 @@ public class DecoderJNI {
 
     private static native void nativePush(long[] context, int length);
 
-    private static native ByteBuffer nativePull(long[] context);
+    private static native ByteBuffer nativePull(long[] context, int length);
 
     private static native void nativeDestroy(long[] context);
 
@@ -123,6 +123,19 @@ public class DecoderJNI {
         }
 
         public ByteBuffer pull() {
+            return pull(0);
+        }
+
+        /**
+         * Pulls decompressed data from the decoder.
+         * @param length number of bytes that the caller is ready to pull from the decoder, 0 if any amount
+         *               could be handled.
+         * @return a buffer which has at most {@code length} bytes available.
+         */
+        public ByteBuffer pull(int length) {
+            if (length < 0) {
+                throw new IllegalArgumentException("negative output length");
+            }
             if (context[0] == 0) {
                 throw new IllegalStateException("brotli decoder is already destroyed");
             }
@@ -130,7 +143,7 @@ public class DecoderJNI {
                 throw new IllegalStateException("pulling output from decoder in " + lastStatus + " state");
             }
             fresh = false;
-            ByteBuffer result = nativePull(context);
+            ByteBuffer result = nativePull(context, length);
             parseStatus();
             return result;
         }

--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/decoder/DirectDecompress.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/decoder/DirectDecompress.java
@@ -52,6 +52,18 @@ public final class DirectDecompress {
     }
 
     /**
+     * Initiate direct decompression of data which is of a known length
+     *
+     * @param compressedData Compressed data as byte array
+     * @param decompressedLength Expected length of the data after it has been decompressed
+     * @return {@link DirectDecompress} Instance containing the status and result of the decompression attempt
+     * @throws IOException In case of some error during decompression
+     */
+    public static DirectDecompress decompressKnownLength(byte[] compressedData, int decompressedLength) throws IOException {
+        return Decoder.decompressKnownLength(compressedData, decompressedLength);
+    }
+
+    /**
      * Get the result of decompression.
      *
      * @return {@link DecoderJNI.Status}

--- a/brotli4j/src/test/java/com/aayushatharva/brotli4j/decoder/DecoderTest.java
+++ b/brotli4j/src/test/java/com/aayushatharva/brotli4j/decoder/DecoderTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class DecoderTest {
 
     private static final byte[] COMPRESSED_DATA = new byte[]{-117, 1, -128, 77, 101, 111, 119, 3};
-    private static final int ORIGINAL_DATA_LENGTH = 4;
+    private static final int ORIGINAL_DATA_LENGTH = 4; // 'Meow' length
 
     @BeforeAll
     static void load() {
@@ -61,16 +61,12 @@ class DecoderTest {
     }
 
     @Test
-    void decompressKnownLengthDataTooBig() throws IOException {
-        assertThrows(IllegalArgumentException.class, () -> {
-                        Decoder.decompressKnownLength(COMPRESSED_DATA, ORIGINAL_DATA_LENGTH - 1);
-                    });
+    void decompressKnownLengthDataTooBig() {
+        assertThrows(IllegalArgumentException.class, () -> Decoder.decompressKnownLength(COMPRESSED_DATA, ORIGINAL_DATA_LENGTH - 1));
     }
 
     @Test
-    void decompressKnownLengthDataTooSmall() throws IOException {
-        assertThrows(IllegalArgumentException.class, () -> {
-                         Decoder.decompressKnownLength(COMPRESSED_DATA, ORIGINAL_DATA_LENGTH + 1);
-                     });
+    void decompressKnownLengthDataTooSmall() {
+        assertThrows(IllegalArgumentException.class, () -> Decoder.decompressKnownLength(COMPRESSED_DATA, ORIGINAL_DATA_LENGTH + 1));
     }
 }

--- a/brotli4j/src/test/java/com/aayushatharva/brotli4j/decoder/DecoderTest.java
+++ b/brotli4j/src/test/java/com/aayushatharva/brotli4j/decoder/DecoderTest.java
@@ -28,7 +28,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class DecoderTest {
 
-    private static final byte[] compressedData = new byte[]{-117, 1, -128, 77, 101, 111, 119, 3};
+    private static final byte[] COMPRESSED_DATA = new byte[]{-117, 1, -128, 77, 101, 111, 119, 3};
+    private static final int ORIGINAL_DATA_LENGTH = 4;
 
     @BeforeAll
     static void load() {
@@ -37,7 +38,7 @@ class DecoderTest {
 
     @Test
     void decompress() throws IOException {
-        DirectDecompress directDecompress = Decoder.decompress(compressedData);
+        DirectDecompress directDecompress = Decoder.decompress(COMPRESSED_DATA);
         assertEquals(DecoderJNI.Status.DONE, directDecompress.getResultStatus());
         assertEquals("Meow", new String(directDecompress.getDecompressedData()));
     }
@@ -50,5 +51,26 @@ class DecoderTest {
         DirectDecompress directDecompress = Decoders.decompress(src, dst);
         assertEquals(DecoderJNI.Status.DONE, directDecompress.getResultStatus());
         assertEquals("Meow", new String(directDecompress.getDecompressedData()));
+    }
+
+    @Test
+    void decompressKnownLength() throws IOException {
+        DirectDecompress directDecompress = Decoder.decompressKnownLength(COMPRESSED_DATA, ORIGINAL_DATA_LENGTH);
+        assertEquals(DecoderJNI.Status.DONE, directDecompress.getResultStatus());
+        assertEquals("Meow", new String(directDecompress.getDecompressedData()));
+    }
+
+    @Test
+    void decompressKnownLengthDataTooBig() throws IOException {
+        assertThrows(IllegalArgumentException.class, () -> {
+                        Decoder.decompressKnownLength(COMPRESSED_DATA, ORIGINAL_DATA_LENGTH - 1);
+                    });
+    }
+
+    @Test
+    void decompressKnownLengthDataTooSmall() throws IOException {
+        assertThrows(IllegalArgumentException.class, () -> {
+                         Decoder.decompressKnownLength(COMPRESSED_DATA, ORIGINAL_DATA_LENGTH + 1);
+                     });
     }
 }

--- a/brotli4j/src/test/java/com/aayushatharva/brotli4j/decoder/DecoderTest.java
+++ b/brotli4j/src/test/java/com/aayushatharva/brotli4j/decoder/DecoderTest.java
@@ -24,11 +24,11 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 class DecoderTest {
 
-    private static final byte[] COMPRESSED_DATA = new byte[]{-117, 1, -128, 77, 101, 111, 119, 3};
+    private static final byte[] COMPRESSED_DATA = {-117, 1, -128, 77, 101, 111, 119, 3};
     private static final int ORIGINAL_DATA_LENGTH = 4; // 'Meow' length
 
     @BeforeAll
@@ -45,7 +45,7 @@ class DecoderTest {
 
     @Test
     void decompressWithByteBuffer() throws IOException {
-        ByteBuf src = Unpooled.wrappedBuffer(compressedData);
+        ByteBuf src = Unpooled.wrappedBuffer(COMPRESSED_DATA);
         ByteBuf dst = Unpooled.directBuffer();
 
         DirectDecompress directDecompress = Decoders.decompress(src, dst);
@@ -62,11 +62,13 @@ class DecoderTest {
 
     @Test
     void decompressKnownLengthDataTooBig() {
-        assertThrows(IllegalArgumentException.class, () -> Decoder.decompressKnownLength(COMPRESSED_DATA, ORIGINAL_DATA_LENGTH - 1));
+        assertThrows(IllegalArgumentException.class,
+                     () -> Decoder.decompressKnownLength(COMPRESSED_DATA, ORIGINAL_DATA_LENGTH - 1));
     }
 
     @Test
     void decompressKnownLengthDataTooSmall() {
-        assertThrows(IllegalArgumentException.class, () -> Decoder.decompressKnownLength(COMPRESSED_DATA, ORIGINAL_DATA_LENGTH + 1));
+        assertThrows(IllegalArgumentException.class,
+                     () -> Decoder.decompressKnownLength(COMPRESSED_DATA, ORIGINAL_DATA_LENGTH + 1));
     }
 }

--- a/natives/src/main/cpp/decoder_jni.cc
+++ b/natives/src/main/cpp/decoder_jni.cc
@@ -184,11 +184,11 @@ Java_com_aayushatharva_brotli4j_decoder_DecoderJNI_nativePush(
  */
 JNIEXPORT jobject JNICALL
 Java_com_aayushatharva_brotli4j_decoder_DecoderJNI_nativePull(
-    JNIEnv* env, jobject /*jobj*/, jlongArray ctx) {
+    JNIEnv* env, jobject /*jobj*/, jlongArray ctx, jint output_length) {
   jlong context[3];
   env->GetLongArrayRegion(ctx, 0, 3, context);
   DecoderHandle* handle = getHandle(reinterpret_cast<void*>(context[0]));
-  size_t data_length = 0;
+  size_t data_length = output_length;
   const uint8_t* data = BrotliDecoderTakeOutput(handle->state, &data_length);
   bool hasMoreOutput = !!BrotliDecoderHasMoreOutput(handle->state);
   if (hasMoreOutput) {


### PR DESCRIPTION
…r allocated when the decompressed size is known.

Motivation:
Limiting the size of buffer allocation can help mitigate the risks of compression bombs. In cases where these could be a legitimate attack vector, we should provide the library caller with the option of limiting the buffer size.
This is necessary to provide Brotli support for RFC8879 https://datatracker.ietf.org/doc/rfc8879/ in netty.

Changes:
 -  Add `decompressKnownLength` method to `Decoder.java` to allow for decompression of known-size payloads.
 -  Add `decompressKnownLength` method to `DirectDecompress.java` to be consistent with `decompress`.
 -  Modify `DecoderJNI.java` and `decoder_jni.cc` to allow users to specify the output buffer size.

Result:
Users which believe that they have known-size payloads can decompress those payloads in linear space complexity based on the expected size rather than unknown space complexity, based on the actual size. This was verified with async-profiler which clearly shows reduced allocation when providing a known size.