### PR TITLE
Add `DirectByteBuffer` check

### DIFF
--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/decoder/Decoder.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/decoder/Decoder.java
@@ -67,6 +67,14 @@ public class Decoder {
      */
     @Local
     public static DirectDecompress decompress(ByteBuffer compressed, ByteBuffer decompressed) throws IOException {
+        if (!compressed.isDirect()) {
+            throw new IllegalArgumentException("Compressed ByteBuffer must be direct");
+        }
+
+        if (!decompressed.isDirect()) {
+            throw new IllegalArgumentException("Decompressed ByteBuffer must be direct");
+        }
+
         int compressedRemaining = compressed.remaining();
         int decompressedPosition = decompressed.position();
         DecoderJNI.Wrapper decoder = new DecoderJNI.Wrapper(compressedRemaining);

--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/encoder/Encoder.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/encoder/Encoder.java
@@ -88,6 +88,14 @@ public class Encoder {
      */
     @Local
     public static void compress(ByteBuffer src, ByteBuffer dst, Parameters params) throws IOException {
+        if (!src.isDirect()) {
+            throw new IllegalArgumentException("Source ByteBuffer must be direct");
+        }
+
+        if (!dst.isDirect()) {
+            throw new IllegalArgumentException("Destination ByteBuffer must be direct");
+        }
+
         int size = src.remaining();
         int dstPosition = dst.position();
         if (!src.hasRemaining()) {

--- a/brotli4j/src/test/java/com/aayushatharva/brotli4j/decoder/DecoderTest.java
+++ b/brotli4j/src/test/java/com/aayushatharva/brotli4j/decoder/DecoderTest.java
@@ -17,6 +17,8 @@
 package com.aayushatharva.brotli4j.decoder;
 
 import com.aayushatharva.brotli4j.Brotli4jLoader;
+import com.aayushatharva.brotli4j.encoder.Encoder;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -49,5 +51,21 @@ class DecoderTest {
         DirectDecompress directDecompress = Decoder.decompress(src, dst);
         assertEquals(DecoderJNI.Status.DONE, directDecompress.getResultStatus());
         assertEquals("Meow", new String(directDecompress.getDecompressedData()));
+    }
+
+    @Test
+    void throwExceptionOnHeapBuffer() {
+        ByteBuffer src = ByteBuffer.allocate(0);
+        ByteBuffer dst = ByteBuffer.allocate(0);
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Decoder.decompress(src, dst));
+    }
+
+    @Test
+    void doesNotThrowExceptionOnHeapBuffer() {
+        ByteBuffer src = ByteBuffer.allocateDirect(0);
+        ByteBuffer dst = ByteBuffer.allocateDirect(0);
+
+        Assertions.assertDoesNotThrow(() -> Decoder.decompress(src, dst));
     }
 }

--- a/brotli4j/src/test/java/com/aayushatharva/brotli4j/decoder/DecoderTest.java
+++ b/brotli4j/src/test/java/com/aayushatharva/brotli4j/decoder/DecoderTest.java
@@ -63,8 +63,8 @@ class DecoderTest {
 
     @Test
     void doesNotThrowExceptionOnHeapBuffer() {
-        ByteBuffer src = ByteBuffer.allocateDirect(0);
-        ByteBuffer dst = ByteBuffer.allocateDirect(0);
+        ByteBuffer src = ByteBuffer.allocateDirect(1);
+        ByteBuffer dst = ByteBuffer.allocateDirect(1);
 
         Assertions.assertDoesNotThrow(() -> Decoder.decompress(src, dst));
     }

--- a/brotli4j/src/test/java/com/aayushatharva/brotli4j/encoder/EncoderTest.java
+++ b/brotli4j/src/test/java/com/aayushatharva/brotli4j/encoder/EncoderTest.java
@@ -50,7 +50,7 @@ class EncoderTest {
     @Test
     void compressWithQualityAndByteBuffer() throws IOException {
         ByteBuffer src = ByteBuffer.wrap("Meow".getBytes(StandardCharsets.UTF_8));
-        ByteBuffer dst = ByteBuffer.allocate(16);
+        ByteBuffer dst = ByteBuffer.allocateDirect(16);
         Encoder.compress(src, dst, new Encoder.Parameters());
 
         byte[] arr = new byte[dst.remaining()];

--- a/brotli4j/src/test/java/com/aayushatharva/brotli4j/encoder/EncoderTest.java
+++ b/brotli4j/src/test/java/com/aayushatharva/brotli4j/encoder/EncoderTest.java
@@ -17,6 +17,7 @@
 package com.aayushatharva.brotli4j.encoder;
 
 import com.aayushatharva.brotli4j.Brotli4jLoader;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -71,5 +72,21 @@ class EncoderTest {
 
         final byte[] compressedFont = Encoder.compress(text, parameters.setMode(Encoder.Mode.FONT));
         assertEquals(31, compressedFont.length);
+    }
+
+    @Test
+    void throwExceptionOnHeapBuffer() {
+        ByteBuffer src = ByteBuffer.allocate(0);
+        ByteBuffer dst = ByteBuffer.allocate(0);
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Encoder.compress(src, dst));
+    }
+
+    @Test
+    void doesNotThrowExceptionOnHeapBuffer() {
+        ByteBuffer src = ByteBuffer.allocateDirect(0);
+        ByteBuffer dst = ByteBuffer.allocateDirect(0);
+
+        Assertions.assertDoesNotThrow(() -> Encoder.compress(src, dst));
     }
 }

--- a/brotli4j/src/test/java/com/aayushatharva/brotli4j/encoder/EncoderTest.java
+++ b/brotli4j/src/test/java/com/aayushatharva/brotli4j/encoder/EncoderTest.java
@@ -84,8 +84,8 @@ class EncoderTest {
 
     @Test
     void doesNotThrowExceptionOnHeapBuffer() {
-        ByteBuffer src = ByteBuffer.allocateDirect(0);
-        ByteBuffer dst = ByteBuffer.allocateDirect(0);
+        ByteBuffer src = ByteBuffer.allocateDirect(1);
+        ByteBuffer dst = ByteBuffer.allocateDirect(1);
 
         Assertions.assertDoesNotThrow(() -> Encoder.compress(src, dst));
     }


### PR DESCRIPTION
`ByteBuffer` must be direct because it is shared via JNI for compression and decompression. So we should have a check on `ByteBuffer` type.