### PR TITLE
Upgrade Netty-Buffer to 4.1.84.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-buffer</artifactId>
-            <version>4.1.79.Final</version>
+            <version>4.1.84.Final</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
Netty-Buffer 4.1.84.Final is released and we should upgrade to it.