### PR TITLE
Fix Brotli4j not working at all in modular environments

### DIFF
--- a/brotli4j/pom.xml
+++ b/brotli4j/pom.xml
@@ -38,7 +38,7 @@
             <plugin>
                 <groupId>org.moditect</groupId>
                 <artifactId>moditect-maven-plugin</artifactId>
-                <version>1.0.0.RC1</version>
+                <version>1.0.0.RC2</version>
                 <executions>
                     <execution>
                         <id>add-module-infos</id>

--- a/brotli4j/pom.xml
+++ b/brotli4j/pom.xml
@@ -29,6 +29,47 @@
     <artifactId>brotli4j</artifactId>
     <packaging>jar</packaging>
 
+    <properties>
+        <javaModuleName>com.aayushatharva.brotli4j</javaModuleName>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.0.0.RC1</version>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <jvmVersion>9</jvmVersion>
+                            <module>
+                                <moduleInfo>
+                                    <name>${javaModuleName}</name>
+                                    <exports>
+                                        com.aayushatharva.brotli4j;
+                                        com.aayushatharva.brotli4j.common;
+                                        com.aayushatharva.brotli4j.decoder;
+                                        com.aayushatharva.brotli4j.encoder;
+                                    </exports>
+                                </moduleInfo>
+                            </module>
+                            <jdepsExtraArgs>
+                                <arg>--multi-release</arg>
+                                <arg>9</arg>
+                            </jdepsExtraArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <profile>
             <id>linux-x86_64</id>

--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/Brotli4jLoader.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/Brotli4jLoader.java
@@ -38,7 +38,8 @@ public class Brotli4jLoader {
         } catch (Throwable t) {
             try {
                 String nativeLibName = System.mapLibraryName("brotli");
-                String libPath = "/lib/" + getPlatform() + "/" + nativeLibName;
+                String platform = getPlatform();
+                String libPath = "/lib/" + platform + "/" + nativeLibName;
 
                 File tempDir = new File(System.getProperty("java.io.tmpdir"), "com_aayushatharva_brotli4j_" + System.nanoTime());
                 tempDir.mkdir();
@@ -46,7 +47,8 @@ public class Brotli4jLoader {
 
                 File tempFile = new File(tempDir, nativeLibName);
 
-                try (InputStream in = Brotli4jLoader.class.getResourceAsStream(libPath)) {
+                Class<?> loaderClassToUse = Class.forName("com.aayushatharva.brotli4j." + platform.replace('-', '.') + ".NativeLoader");
+                try (InputStream in = loaderClassToUse.getResourceAsStream(libPath)) {
                     Files.copy(in, tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
                 } catch (Throwable throwable) {
                     tempFile.delete();

--- a/natives/linux-aarch64/pom.xml
+++ b/natives/linux-aarch64/pom.xml
@@ -38,7 +38,7 @@
             <plugin>
                 <groupId>org.moditect</groupId>
                 <artifactId>moditect-maven-plugin</artifactId>
-                <version>1.0.0.RC1</version>
+                <version>1.0.0.RC2</version>
                 <executions>
                     <execution>
                         <id>add-module-infos</id>
@@ -51,6 +51,9 @@
                             <module>
                                 <moduleInfo>
                                     <name>${javaModuleName}</name>
+                                    <exports>
+                                        ${javaModuleName} to com.aayushatharva.brotli4j;
+                                    </exports>
                                 </moduleInfo>
                             </module>
                             <jdepsExtraArgs>

--- a/natives/linux-aarch64/pom.xml
+++ b/natives/linux-aarch64/pom.xml
@@ -29,6 +29,41 @@
     <artifactId>native-linux-aarch64</artifactId>
     <packaging>jar</packaging>
 
+    <properties>
+        <javaModuleName>com.aayushatharva.brotli4j.linux.aarch64</javaModuleName>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.0.0.RC1</version>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <jvmVersion>9</jvmVersion>
+                            <module>
+                                <moduleInfo>
+                                    <name>${javaModuleName}</name>
+                                </moduleInfo>
+                            </module>
+                            <jdepsExtraArgs>
+                                <arg>--multi-release</arg>
+                                <arg>9</arg>
+                            </jdepsExtraArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <profile>
             <id>linux-aarch64</id>

--- a/natives/linux-aarch64/src/main/java/com/aayushatharva/brotli4j/linux/aarch64/NativeLoader.java
+++ b/natives/linux-aarch64/src/main/java/com/aayushatharva/brotli4j/linux/aarch64/NativeLoader.java
@@ -1,0 +1,7 @@
+package com.aayushatharva.brotli4j.linux.aarch64;
+
+/**
+ * Empty class to access the native lib in a JPMS context
+ */
+public class NativeLoader {
+}

--- a/natives/linux-x86_64/pom.xml
+++ b/natives/linux-x86_64/pom.xml
@@ -38,7 +38,7 @@
             <plugin>
                 <groupId>org.moditect</groupId>
                 <artifactId>moditect-maven-plugin</artifactId>
-                <version>1.0.0.RC1</version>
+                <version>1.0.0.RC2</version>
                 <executions>
                     <execution>
                         <id>add-module-infos</id>
@@ -51,6 +51,9 @@
                             <module>
                                 <moduleInfo>
                                     <name>${javaModuleName}</name>
+                                    <exports>
+                                        ${javaModuleName} to com.aayushatharva.brotli4j;
+                                    </exports>
                                 </moduleInfo>
                             </module>
                             <jdepsExtraArgs>

--- a/natives/linux-x86_64/pom.xml
+++ b/natives/linux-x86_64/pom.xml
@@ -29,6 +29,41 @@
     <artifactId>native-linux-x86_64</artifactId>
     <packaging>jar</packaging>
 
+    <properties>
+        <javaModuleName>com.aayushatharva.brotli4j.linux.x86_64</javaModuleName>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.0.0.RC1</version>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <jvmVersion>9</jvmVersion>
+                            <module>
+                                <moduleInfo>
+                                    <name>${javaModuleName}</name>
+                                </moduleInfo>
+                            </module>
+                            <jdepsExtraArgs>
+                                <arg>--multi-release</arg>
+                                <arg>9</arg>
+                            </jdepsExtraArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <profile>
             <id>linux-x86_64</id>

--- a/natives/linux-x86_64/src/main/java/com/aayushatharva/brotli4j/linux/x86_64/NativeLoader.java
+++ b/natives/linux-x86_64/src/main/java/com/aayushatharva/brotli4j/linux/x86_64/NativeLoader.java
@@ -1,0 +1,7 @@
+package com.aayushatharva.brotli4j.linux.x86_64;
+
+/**
+ * Empty class to access the native lib in a JPMS context
+ */
+public class NativeLoader {
+}

--- a/natives/osx-aarch64/pom.xml
+++ b/natives/osx-aarch64/pom.xml
@@ -29,6 +29,44 @@
     <artifactId>native-osx-aarch64</artifactId>
     <packaging>jar</packaging>
 
+    <properties>
+        <javaModuleName>com.aayushatharva.brotli4j.macos.aarch64</javaModuleName>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.0.0.RC2</version>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <jvmVersion>9</jvmVersion>
+                            <module>
+                                <moduleInfo>
+                                    <name>${javaModuleName}</name>
+                                    <exports>
+                                        ${javaModuleName} to com.aayushatharva.brotli4j;
+                                    </exports>
+                                </moduleInfo>
+                            </module>
+                            <jdepsExtraArgs>
+                                <arg>--multi-release</arg>
+                                <arg>9</arg>
+                            </jdepsExtraArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
 
         <profile>

--- a/natives/osx-aarch64/src/main/java/com/aayushatharva/brotli4j/macos/aarch64/NativeLoader.java
+++ b/natives/osx-aarch64/src/main/java/com/aayushatharva/brotli4j/macos/aarch64/NativeLoader.java
@@ -1,0 +1,7 @@
+package com.aayushatharva.brotli4j.macos.aarch64;
+
+/**
+ * Empty class to access the native lib in a JPMS context
+ */
+public class NativeLoader {
+}

--- a/natives/osx-x86_64/pom.xml
+++ b/natives/osx-x86_64/pom.xml
@@ -38,7 +38,7 @@
             <plugin>
                 <groupId>org.moditect</groupId>
                 <artifactId>moditect-maven-plugin</artifactId>
-                <version>1.0.0.RC1</version>
+                <version>1.0.0.RC2</version>
                 <executions>
                     <execution>
                         <id>add-module-infos</id>
@@ -51,6 +51,9 @@
                             <module>
                                 <moduleInfo>
                                     <name>${javaModuleName}</name>
+                                    <exports>
+                                        ${javaModuleName} to com.aayushatharva.brotli4j;
+                                    </exports>
                                 </moduleInfo>
                             </module>
                             <jdepsExtraArgs>

--- a/natives/osx-x86_64/pom.xml
+++ b/natives/osx-x86_64/pom.xml
@@ -29,6 +29,41 @@
     <artifactId>native-osx-x86_64</artifactId>
     <packaging>jar</packaging>
 
+    <properties>
+        <javaModuleName>com.aayushatharva.brotli4j.macos.x86_64</javaModuleName>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.0.0.RC1</version>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <jvmVersion>9</jvmVersion>
+                            <module>
+                                <moduleInfo>
+                                    <name>${javaModuleName}</name>
+                                </moduleInfo>
+                            </module>
+                            <jdepsExtraArgs>
+                                <arg>--multi-release</arg>
+                                <arg>9</arg>
+                            </jdepsExtraArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
 
         <profile>

--- a/natives/osx-x86_64/src/main/java/com/aayushatharva/brotli4j/macos/x86_64/NativeLoader.java
+++ b/natives/osx-x86_64/src/main/java/com/aayushatharva/brotli4j/macos/x86_64/NativeLoader.java
@@ -1,0 +1,7 @@
+package com.aayushatharva.brotli4j.macos.x86_64;
+
+/**
+ * Empty class to access the native lib in a JPMS context
+ */
+public class NativeLoader {
+}

--- a/natives/windows-x86_64/pom.xml
+++ b/natives/windows-x86_64/pom.xml
@@ -29,6 +29,41 @@
     <artifactId>native-windows-x86_64</artifactId>
     <packaging>jar</packaging>
 
+    <properties>
+        <javaModuleName>com.aayushatharva.brotli4j.windows.x86_64</javaModuleName>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.0.0.RC1</version>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <jvmVersion>9</jvmVersion>
+                            <module>
+                                <moduleInfo>
+                                    <name>${javaModuleName}</name>
+                                </moduleInfo>
+                            </module>
+                            <jdepsExtraArgs>
+                                <arg>--multi-release</arg>
+                                <arg>9</arg>
+                            </jdepsExtraArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <profile>
             <id>windows-x86_64</id>

--- a/natives/windows-x86_64/pom.xml
+++ b/natives/windows-x86_64/pom.xml
@@ -38,7 +38,7 @@
             <plugin>
                 <groupId>org.moditect</groupId>
                 <artifactId>moditect-maven-plugin</artifactId>
-                <version>1.0.0.RC1</version>
+                <version>1.0.0.RC2</version>
                 <executions>
                     <execution>
                         <id>add-module-infos</id>
@@ -51,6 +51,9 @@
                             <module>
                                 <moduleInfo>
                                     <name>${javaModuleName}</name>
+                                    <exports>
+                                        ${javaModuleName} to com.aayushatharva.brotli4j;
+                                    </exports>
                                 </moduleInfo>
                             </module>
                             <jdepsExtraArgs>

--- a/natives/windows-x86_64/src/main/java/com/aayushatharva/brotli4j/windows/x86_64/NativeLoader.java
+++ b/natives/windows-x86_64/src/main/java/com/aayushatharva/brotli4j/windows/x86_64/NativeLoader.java
@@ -1,0 +1,7 @@
+package com.aayushatharva.brotli4j.windows.x86_64;
+
+/**
+ * Empty class to access the native lib in a JPMS context
+ */
+public class NativeLoader {
+}

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,18 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Multi-Release>true</Multi-Release>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Follow-up to #26

This system allows brotli4j to work in a JMPS environment while still working with Java 8 or newer non-modular setups.
I've based this on the work done in #26, but expanded it to the new arch (mac aarch64) and made it actually work in production environments.
The change of adding a new class to every native module is needed as when the jars are loaded in modular context, a class of one module cannot access the resources of another module.
I am not sure if there is a better way of doing this without sacrificing non-JMPS and j8 support, but this sould be fairly straightforward.


Fixes #24
Fixes #25 