### PR TITLE
avoid array allocation in Encoder.Mode.of

### DIFF
--- a/brotli4j-tests/src/test/java/com/aayushatharva/brotli4j/encoder/EncoderTest.java
+++ b/brotli4j-tests/src/test/java/com/aayushatharva/brotli4j/encoder/EncoderTest.java
@@ -70,4 +70,11 @@ class EncoderTest {
         final byte[] compressedFont = Encoder.compress(text, parameters.setMode(Encoder.Mode.FONT));
         assertEquals(31, compressedFont.length);
     }
+
+    @Test
+    void encodeModeEnumValues() {
+        assertEquals(Encoder.Mode.FONT, Encoder.Mode.of(Encoder.Mode.FONT.ordinal()));
+        assertEquals(Encoder.Mode.TEXT, Encoder.Mode.of(Encoder.Mode.TEXT.ordinal()));
+        assertEquals(Encoder.Mode.GENERIC, Encoder.Mode.of(Encoder.Mode.GENERIC.ordinal()));
+    }
 }

--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/encoder/Encoder.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/encoder/Encoder.java
@@ -221,10 +221,14 @@ public class Encoder {
          */
         FONT;
 
+        // see: https://www.gamlor.info/wordpress/2017/08/javas-enum-values-hidden-allocations/
+        private static final Mode[] ALL_VALUES = values();
+
         public static Mode of(int value) {
-            return values()[value];
+            return ALL_VALUES[value];
         }
     }
+
 
     /**
      * Brotli encoder settings.


### PR DESCRIPTION
Reference:

https://www.gamlor.info/wordpress/2017/08/javas-enum-values-hidden-allocations/
