### PR TITLE
Include extracted nativeLib-file in on-exit deletion of Brotli4jLoader

### DIFF
--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/Brotli4jLoader.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/Brotli4jLoader.java
@@ -75,6 +75,7 @@ public class Brotli4jLoader {
                     }
 
                     System.load(tempFile.getAbsolutePath());
+                    tempFile.deleteOnExit();
                 } catch (Throwable throwable) {
                     cause = throwable;
                 }


### PR DESCRIPTION
The intended auto-cleanup of the temporary directories which may be created by `Brotli4jLoader` for the native libraries isn't working as intended. I noticed more and more leftover directories piling up and never being removed again, at:
```
/tmp/com_aayushatharva_brotli4j_<timestamp>
```

Tiny fix to improve this, is to also register the extracted files in those directories for `deleteOnExit()` along.