### PR TITLE
netty 4.1.95

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-buffer</artifactId>
-            <version>4.1.93.Final</version>
+            <version>4.1.95.Final</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
Motivation:

bump Netty version to latest (4.1.95)

https://netty.io/news/2023/07/20/4-1-95-Final.html


Modification:

changed Netty version number

Result:

Test suite passes.
