### PR TITLE
Use '-Xcheck:jni' during testsuite run to detect JNI bugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.1.0</version>
                 <configuration>
-                    <argLine>-Xmx2G</argLine>
+                    <argLine>-Xmx2G -Xcheck:jni</argLine>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
# Motivation:

We should run our testsuite with '-Xcheck:jni' to ensure we catch bugs in our JNI code which could later cause issues like crashes

# Modifications:

Add -Xcheck:jni

# Result:

Testsuite will be able to catch more JNI bugs

 

# Related work:
This PR was inspired by a Netty PR:
https://github.com/netty/netty/pull/13642

# Related tweet:

<img width="744" alt="image" src="https://github.com/hyperxpro/Brotli4j/assets/30938/106d737c-8bcb-4d91-adb9-8b550ca46ae2">
