### PR TITLE
Prepare for v1.13.0 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For maven, the natives will
 <dependency>
     <groupId>com.aayushatharva.brotli4j</groupId>
     <artifactId>brotli4j</artifactId>
-    <version>1.12.0</version>
+    <version>1.13.0</version>
 </dependency>
 ```
 
@@ -44,7 +44,7 @@ Of course, you can add native(s) as dependency manually also.
 import org.gradle.nativeplatform.platform.internal.Architectures
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 
-val brotliVersion = "1.12.0"
+val brotliVersion = "1.13.0"
 val operatingSystem: OperatingSystem = DefaultNativePlatform.getCurrentOperatingSystem()
 
 repositories {
@@ -78,7 +78,7 @@ dependencies {
 import org.gradle.nativeplatform.platform.internal.Architectures
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 
-def brotliVersion = "1.12.0"
+def brotliVersion = "1.13.0"
 def operatingSystem = DefaultNativePlatform.getCurrentOperatingSystem()
 
 repositories {

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.aayushatharva.brotli4j</groupId>
         <artifactId>brotli4j-parent</artifactId>
-        <version>1.12.0</version>
+        <version>1.13.0</version>
     </parent>
 
     <artifactId>all</artifactId>

--- a/brotli4j/pom.xml
+++ b/brotli4j/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>brotli4j-parent</artifactId>
         <groupId>com.aayushatharva.brotli4j</groupId>
-        <version>1.12.0</version>
+        <version>1.13.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/natives/linux-aarch64/pom.xml
+++ b/natives/linux-aarch64/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>natives</artifactId>
         <groupId>com.aayushatharva.brotli4j</groupId>
-        <version>1.12.0</version>
+        <version>1.13.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/natives/linux-armv7/pom.xml
+++ b/natives/linux-armv7/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>natives</artifactId>
         <groupId>com.aayushatharva.brotli4j</groupId>
-        <version>1.12.0</version>
+        <version>1.13.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/natives/linux-s390x/pom.xml
+++ b/natives/linux-s390x/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>natives</artifactId>
         <groupId>com.aayushatharva.brotli4j</groupId>
-        <version>1.12.0</version>
+        <version>1.13.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/natives/linux-x86_64/pom.xml
+++ b/natives/linux-x86_64/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>natives</artifactId>
         <groupId>com.aayushatharva.brotli4j</groupId>
-        <version>1.12.0</version>
+        <version>1.13.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/natives/osx-aarch64/pom.xml
+++ b/natives/osx-aarch64/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>natives</artifactId>
         <groupId>com.aayushatharva.brotli4j</groupId>
-        <version>1.12.0</version>
+        <version>1.13.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/natives/osx-x86_64/pom.xml
+++ b/natives/osx-x86_64/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>natives</artifactId>
         <groupId>com.aayushatharva.brotli4j</groupId>
-        <version>1.12.0</version>
+        <version>1.13.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/natives/pom.xml
+++ b/natives/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.aayushatharva.brotli4j</groupId>
         <artifactId>brotli4j-parent</artifactId>
-        <version>1.12.0</version>
+        <version>1.13.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/natives/windows-x86_64/pom.xml
+++ b/natives/windows-x86_64/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>natives</artifactId>
         <groupId>com.aayushatharva.brotli4j</groupId>
-        <version>1.12.0</version>
+        <version>1.13.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>com.aayushatharva.brotli4j</groupId>
     <artifactId>brotli4j-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.12.0</version>
+    <version>1.13.0</version>
 
     <name>Brotli4j</name>
     <description>Brotli4j provides Brotli compression and decompression for Java.</description>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.aayushatharva.brotli4j</groupId>
         <artifactId>brotli4j-parent</artifactId>
-        <version>1.12.0</version>
+        <version>1.13.0</version>
     </parent>
 
     <artifactId>service</artifactId>


### PR DESCRIPTION
Prepare for v1.13.0 Release

Changelog:
1. Dependencies update
2. [s390x architecture support](https://github.com/hyperxpro/Brotli4j/pull/102)
3. [Use '-Xcheck:jni' during testsuite run to detect JNI bugs](https://github.com/hyperxpro/Brotli4j/pull/107)
4. [Make flush and encode public](https://github.com/hyperxpro/Brotli4j/commit/e5489332cc3afa4b279475f6c9580047f9533f32)
5. [rotli v1.1.0 Sync](https://github.com/hyperxpro/Brotli4j/pull/109)