### PR TITLE
Finish adding `native-linux-riscv64` architecture support

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,7 +26,7 @@ jobs:
           java-version: 8
           architecture: x64
       - name: Build with Maven
-        run: mvn -B -ntp clean package --file pom.xml
+        run: mvn -B --show-version -ntp clean package --file pom.xml
       - name: Upload the build
         uses: actions/upload-artifact@v3
         with:
@@ -44,7 +44,7 @@ jobs:
           java-version: 11
           architecture: x64
       - name: Build with Maven
-        run: mvn -B -ntp clean package --file pom.xml
+        run: mvn -B --show-version -ntp --file pom.xml clean package
 
   MacOS-x86_64-Build-JDK17:
     runs-on: macos-latest
@@ -57,7 +57,7 @@ jobs:
           java-version: 17
           architecture: x64
       - name: Build with Maven
-        run: mvn -B -ntp clean package --file pom.xml
+        run: mvn -B --show-version -ntp --file pom.xml clean package
 
   Linux-x86_64-Build-JDK8:
     runs-on: ubuntu-latest
@@ -98,7 +98,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pr-${{ env.cache-name }}-
             ${{ runner.os }}-pr-
-      - uses: uraimo/run-on-arch-action@v2.3.0
+      - uses: uraimo/run-on-arch-action@v2.4.0
         name: Run commands
         id: runcmd
         with:
@@ -125,7 +125,7 @@ jobs:
           run: |
             export JAVA_HOME="/jdk"
             chmod +x ./mvnw
-            ./mvnw -B -ntp clean package
+            ./mvnw -B --show-version -ntp clean package
 
       - name: Upload the build
         uses: actions/upload-artifact@v3
@@ -145,7 +145,7 @@ jobs:
           key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-pr-${{ matrix.arch }}-pr-${{ env.cache-name }}-pr-
-      - uses: uraimo/run-on-arch-action@v2.3.0
+      - uses: uraimo/run-on-arch-action@v2.4.0
         name: Run commands
         id: runcmd
         with:
@@ -172,7 +172,7 @@ jobs:
           run: |
             export JAVA_HOME="/jdk"
             chmod +x ./mvnw
-            ./mvnw -B -ntp clean package
+            ./mvnw -B --show-version -ntp clean package
 
   Linux-Aarch64-Build-JDK17:
     runs-on: ubuntu-latest
@@ -186,7 +186,7 @@ jobs:
           key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-pr-${{ matrix.arch }}-pr-${{ env.cache-name }}-pr-
-      - uses: uraimo/run-on-arch-action@v2.3.0
+      - uses: uraimo/run-on-arch-action@v2.4.0
         name: Run commands
         id: runcmd
         with:
@@ -214,7 +214,7 @@ jobs:
             export MAVEN_OPTS="-Djdk.lang.Process.launchMechanism=vfork"
             export JAVA_HOME="/jdk"
             chmod +x ./mvnw
-            ./mvnw -B -ntp clean package
+            ./mvnw -B --show-version -ntp clean package
 
   Linux-ArmV7-Build-JDK8:
     runs-on: ubuntu-latest
@@ -228,7 +228,7 @@ jobs:
           key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-pr-${{ matrix.arch }}-pr-${{ env.cache-name }}-pr-
-      - uses: uraimo/run-on-arch-action@v2.3.0
+      - uses: uraimo/run-on-arch-action@v2.4.0
         name: Run commands
         id: runcmd
         with:
@@ -255,7 +255,7 @@ jobs:
           run: |
             export JAVA_HOME="/jdk"
             chmod +x ./mvnw
-            ./mvnw -B -ntp clean package
+            ./mvnw -B --show-version -ntp clean package
 
       - name: Upload the build
         uses: actions/upload-artifact@v3
@@ -275,7 +275,7 @@ jobs:
           key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-pr-${{ matrix.arch }}-pr-${{ env.cache-name }}-pr-
-      - uses: uraimo/run-on-arch-action@v2.3.0
+      - uses: uraimo/run-on-arch-action@v2.4.0
         name: Run commands
         id: runcmd
         with:
@@ -302,7 +302,7 @@ jobs:
           run: |
             export JAVA_HOME="/jdk"
             chmod +x ./mvnw
-            ./mvnw -B -ntp clean package
+            ./mvnw -B --show-version -ntp clean package
             
   Linux-s390x-Build-JDK8:
     runs-on: ubuntu-latest
@@ -316,7 +316,7 @@ jobs:
           key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-pr-${{ matrix.arch }}-pr-${{ env.cache-name }}-pr-
-      - uses: uraimo/run-on-arch-action@v2.3.0
+      - uses: uraimo/run-on-arch-action@v2.4.0
         name: Run commands
         id: runcmd
         with:
@@ -339,7 +339,7 @@ jobs:
           
           run: |
             chmod +x ./mvnw
-            ./mvnw -B -ntp clean package
+            ./mvnw -B --show-version -ntp clean package
 
       - name: Upload the build
         uses: actions/upload-artifact@v3
@@ -359,7 +359,7 @@ jobs:
           key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-pr-${{ matrix.arch }}-pr-${{ env.cache-name }}-pr-
-      - uses: uraimo/run-on-arch-action@v2.3.0
+      - uses: uraimo/run-on-arch-action@v2.4.0
         name: Run commands
         id: runcmd
         with:
@@ -382,7 +382,160 @@ jobs:
 
           run: |
             chmod +x ./mvnw
-            ./mvnw -B -ntp clean package
+            ./mvnw -B --show-version -ntp clean package
+
+  Linux-riscv64-Build-JDK11:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        env:
+          cache-name: cache-m2-repository-${{ runner.os }}-jdk11-riscv64
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-pr-${{ matrix.arch }}-pr-${{ env.cache-name }}-pr-
+
+      - uses: uraimo/run-on-arch-action@v2.4.0
+        name: Run commands
+        id: runcmd
+        with:
+          arch: riscv64
+          distro: ubuntu20.04
+
+          # Not required, but speeds up builds by storing container images in
+          # a GitHub package registry.
+          githubToken: ${{ github.token }}
+
+          # Mount the .m2/repository
+          dockerRunArgs: |
+            --platform linux/riscv64
+            --volume "/home/runner/.m2/repository/:/root/.m2/repository"
+          # Install dependencies
+          install: |
+            apt-get update
+            apt-get install -q -y curl gnupg2 autoconf automake libtool make tar git cmake build-essential openjdk-11-jdk
+
+          run: |
+            export MAVEN_OPTS="-Djdk.lang.Process.launchMechanism=vfork"
+            chmod +x ./mvnw
+            ./mvnw -B --show-version -ntp clean package
+
+      - uses: uraimo/run-on-arch-action@v2.4.0
+        name: Test on JDK 8
+        id: test
+        with:
+          arch: aarch64
+          distro: ubuntu20.04
+
+          # Not required, but speeds up builds by storing container images in
+          # a GitHub package registry.
+          githubToken: ${{ github.token }}
+
+          # Mount the .m2/repository
+          dockerRunArgs: |
+            --platform linux/aarch64
+            --volume "/home/runner/.m2/repository/:/root/.m2/repository"
+
+          # Install dependencies
+          install: |
+            apt-get update
+            apt-get install -q -y curl gnupg2 autoconf automake libtool make tar git cmake build-essential openjdk-8-jdk
+
+          run: |
+            export MAVEN_OPTS="-Djdk.lang.Process.launchMechanism=vfork"
+            chmod +x ./mvnw
+            # Build native-linux-aarch64 only
+            ./mvnw -B --show-version -ntp clean package -pl :native-linux-aarch64 -DskipTests
+            # Test with JDK 8
+            ./mvnw -B --show-version -ntp surefire:test
+
+      # RISC-V doesn't upload the JDK 8 build because JDK 8 doesn't exist on RISC-V. Instead, we upload
+      # the JDK 11 build. It should work on JDK 8 as well, as we are testing it on all other platforms.
+      - name: Upload the build
+        uses: actions/upload-artifact@v3
+        with:
+          name: Linux-riscv64-Build-JDK11
+          path: /home/runner/work/Brotli4j/
+
+  Linux-riscv64-Build-JDK17:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        env:
+          cache-name: cache-m2-repository-${{ runner.os }}-jdk17-riscv64
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-pr-${{ matrix.arch }}-pr-${{ env.cache-name }}-pr-
+      - uses: uraimo/run-on-arch-action@v2.4.0
+        name: Run commands
+        id: runcmd
+        with:
+          arch: riscv64
+          distro: ubuntu20.04
+
+          # Not required, but speeds up builds by storing container images in
+          # a GitHub package registry.
+          githubToken: ${{ github.token }}
+
+          # Mount the .m2/repository
+          dockerRunArgs: |
+            --platform linux/riscv64
+            --volume "/home/runner/.m2/repository/:/root/.m2/repository"
+          # Install dependencies
+          install: |
+            apt-get update
+            apt-get install -q -y curl gnupg2 autoconf automake libtool make tar git cmake build-essential openjdk-17-jdk
+
+          run: |
+            export MAVEN_OPTS="-Djdk.lang.Process.launchMechanism=vfork"
+            chmod +x ./mvnw
+            ./mvnw -B --show-version -ntp clean package
+
+  Linux-riscv64-Build-JDK21:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        env:
+          cache-name: cache-m2-repository-${{ runner.os }}-jdk21-riscv64
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-pr-${{ matrix.arch }}-pr-${{ env.cache-name }}-pr-
+      - uses: uraimo/run-on-arch-action@v2.4.0
+        name: Run commands
+        id: runcmd
+        with:
+          arch: riscv64
+          distro: ubuntu22.04
+
+          # Not required, but speeds up builds by storing container images in
+          # a GitHub package registry.
+          githubToken: ${{ github.token }}
+
+          # Mount the .m2/repository
+          dockerRunArgs: |
+            --platform linux/riscv64
+            --volume "/home/runner/.m2/repository/:/root/.m2/repository"
+
+          # Install dependencies
+          install: |
+            apt-get update
+            apt-get install -q -y curl gnupg2 autoconf automake libtool make tar git cmake build-essential
+
+            curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | bash && . ~/.jabba/jabba.sh
+            jabba install 21-custom=tgz+https://api.adoptium.net/v3/binary/latest/21/ea/linux/riscv64/jdk/hotspot/normal/eclipse?project=jdk -o /jdk
+
+          run: |
+            export JAVA_HOME="/jdk"
+            chmod +x ./mvnw
+            ./mvnw -B --show-version -ntp clean package
 
   Windows-x86_64-Build-JDK8:
     runs-on: windows-latest
@@ -397,7 +550,7 @@ jobs:
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@v1.12.0
       - name: Build with Maven
-        run: mvn -B -ntp clean package --file pom.xml
+        run: mvn -B --show-version -ntp clean package --file pom.xml
       - name: Upload the build
         uses: actions/upload-artifact@v3
         with:
@@ -418,7 +571,7 @@ jobs:
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@v1.12.0
       - name: Build with Maven
-        run: mvn -B -ntp clean package --file pom.xml
+        run: mvn -B --show-version -ntp --file pom.xml clean package
 
   Windows-x86_64-Build-JDK17:
     runs-on: windows-latest
@@ -433,4 +586,4 @@ jobs:
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@v1.12.0
       - name: Build with Maven
-        run: mvn -B -ntp clean package --file pom.xml
+        run: mvn -B --show-version -ntp --file pom.xml clean package

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -66,6 +66,11 @@
             </dependency>
             <dependency>
                 <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-linux-riscv64</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
                 <artifactId>native-osx-aarch64</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/brotli4j/pom.xml
+++ b/brotli4j/pom.xml
@@ -111,6 +111,23 @@
         </profile>
 
         <profile>
+            <id>linux-riscv64</id>
+            <activation>
+                <os>
+                    <family>Linux</family>
+                    <arch>riscv64</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.aayushatharva.brotli4j</groupId>
+                    <artifactId>native-linux-riscv64</artifactId>
+                    <version>${project.parent.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
             <id>windows-x86_64</id>
             <activation>
                 <os>

--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/Brotli4jLoader.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/Brotli4jLoader.java
@@ -128,6 +128,8 @@ public class Brotli4jLoader {
                 return "linux-armv7";
             } else if ("s390x".equalsIgnoreCase(archName)) {
                 return "linux-s390x";
+            } else if ("riscv64".equalsIgnoreCase(archName)) {
+                return "linux-riscv64";
             }
         } else if (osName.startsWith("Windows")) {
             if ("amd64".equalsIgnoreCase(archName)) {

--- a/docker/docker-compose11.yml
+++ b/docker/docker-compose11.yml
@@ -18,7 +18,7 @@ services:
 
   build:
     <<: *common
-    command: /bin/bash -cl "mvn -B -ntp clean package --file pom.xml"
+    command: /bin/bash -cl "mvn -B --show-version -ntp --file pom.xml clean package"
 
   shell:
     <<: *common

--- a/docker/docker-compose17.yml
+++ b/docker/docker-compose17.yml
@@ -18,7 +18,7 @@ services:
 
   build:
     <<: *common
-    command: /bin/bash -cl "mvn -B -ntp clean package --file pom.xml"
+    command: /bin/bash -cl "mvn -B --show-version -ntp --file pom.xml clean package"
 
   shell:
     <<: *common

--- a/natives/linux-riscv64/build.sh
+++ b/natives/linux-riscv64/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+CURPATH=$(pwd)
+TARGET_CLASSES_PATH="target/classes/lib/linux-riscv64"
+TARGET_PATH="target"
+
+exitWithError() {
+  cd ${CURPATH}
+  echo "*** An error occurred. Please check log messages. ***"
+  exit $1
+}
+
+mkdir -p "$TARGET_CLASSES_PATH"
+
+cd "$TARGET_PATH"
+cmake ../../../ || exitWithError $?
+make || exitWithError $?
+rm -f "$CURPATH/${TARGET_CLASSES_PATH}/libbrotli.so"
+cp "./libbrotli.so" "$CURPATH/${TARGET_CLASSES_PATH}" || exitWithError $?
+
+cd "${CURPATH}"

--- a/natives/linux-riscv64/pom.xml
+++ b/natives/linux-riscv64/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2020-2023, Aayush Atharva
+
+  Brotli4j licenses this file to you under the
+  Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>natives</artifactId>
+        <groupId>com.aayushatharva.brotli4j</groupId>
+        <version>1.12.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>native-linux-riscv64</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <javaModuleName>com.aayushatharva.brotli4j.linux.riscv64</javaModuleName>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.0.0.RC2</version>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <jvmVersion>9</jvmVersion>
+                            <module>
+                                <moduleInfoSource>
+                                    module ${javaModuleName} {
+                                    requires com.aayushatharva.brotli4j.service;
+                                    exports ${javaModuleName} to com.aayushatharva.brotli4j;
+                                    provides com.aayushatharva.brotli4j.service.BrotliNativeProvider with
+                                    ${javaModuleName}.NativeLoader;
+                                    }
+                                </moduleInfoSource>
+                            </module>
+                            <jdepsExtraArgs>
+                                <arg>--multi-release</arg>
+                                <arg>9</arg>
+                            </jdepsExtraArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>linux-riscv64</id>
+            <activation>
+                <os>
+                    <family>Linux</family>
+                    <arch>riscv64</arch>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <id>build-native</id>
+                                <phase>process-classes</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>/bin/bash</executable>
+                                    <arguments>
+                                        <argument>build.sh</argument>
+                                    </arguments>
+                                    <workingDirectory>${project.basedir}</workingDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>release</id>
+            <build>
+                <resources>
+                    <resource>
+                        <directory>resources</directory>
+                    </resource>
+                </resources>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/natives/linux-riscv64/src/main/java/com/aayushatharva/brotli4j/linux/riscv64/NativeLoader.java
+++ b/natives/linux-riscv64/src/main/java/com/aayushatharva/brotli4j/linux/riscv64/NativeLoader.java
@@ -1,0 +1,30 @@
+/*
+ *    Copyright (c) 2020-2023, Aayush Atharva
+ *
+ *    Brotli4j licenses this file to you under the
+ *    Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.aayushatharva.brotli4j.linux.riscv64;
+
+import com.aayushatharva.brotli4j.service.BrotliNativeProvider;
+
+/**
+ * Service class to access the native lib in a JPMS context
+ */
+public class NativeLoader implements BrotliNativeProvider {
+
+    @Override
+    public String platformName() {
+        return "linux-riscv64";
+    }
+}

--- a/natives/pom.xml
+++ b/natives/pom.xml
@@ -32,6 +32,7 @@
         <module>linux-aarch64</module>
         <module>linux-armv7</module>
         <module>linux-s390x</module>
+        <module>linux-riscv64</module>
         <module>windows-x86_64</module>
         <module>osx-x86_64</module>
         <module>osx-aarch64</module>
@@ -100,6 +101,19 @@
         </profile>
 
         <profile>
+            <id>linux-riscv64</id>
+            <activation>
+                <os>
+                    <family>Linux</family>
+                    <arch>riscv64</arch>
+                </os>
+            </activation>
+            <modules>
+                <module>linux-riscv64</module>
+            </modules>
+        </profile>
+
+        <profile>
             <id>windows-x86_64</id>
             <activation>
                 <os>
@@ -145,6 +159,7 @@
                 <module>linux-aarch64</module>
                 <module>linux-armv7</module>
                 <module>linux-s390x</module>
+                <module>linux-riscv64</module>
                 <module>windows-x86_64</module>
                 <module>osx-x86_64</module>
                 <module>osx-aarch64</module>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,18 @@
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
+    <profiles>
+        <profile>
+            <id>jdk9+</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.release>8</maven.compiler.release>
+            </properties>
+        </profile>
+    </profiles>
+
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
@@ -107,6 +119,12 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.6.0</version>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
Motivation:

This patch adds support for linux-riscv64.
There was no code change other than adding support for linux-riscv64.

Modification:

It requires updating uraimo/run-on-arch-action to v2.4.0 for support for riscv64. It also uses JDK 21 for riscv64 as it's the first LTS version with support for riscv64 (backports to JDK 17 done and JDK 11 in progress).

Result:
Support for riscv64 architecture.
