### PR TITLE
Add JDK 21 Builds

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -59,6 +59,19 @@ jobs:
       - name: Build with Maven
         run: mvn -B --show-version -ntp --file pom.xml clean package
 
+  MacOS-x86_64-Build-JDK21:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: 21
+          architecture: x64
+      - name: Build with Maven
+        run: mvn -B --show-version -ntp --file pom.xml clean package
+
   Linux-x86_64-Build-JDK8:
     runs-on: ubuntu-latest
     steps:
@@ -84,6 +97,13 @@ jobs:
       - uses: actions/checkout@v3
       - name: build centos6
         run: docker-compose -f docker/docker-compose17.yml run build
+
+  Linux-x86_64-Build-JDK21:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: build centos6
+        run: docker-compose -f docker/docker-compose21.yml run build
 
   Linux-Aarch64-Build-JDK8:
     runs-on: ubuntu-latest
@@ -210,6 +230,48 @@ jobs:
             curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | bash && . ~/.jabba/jabba.sh
             jabba install 17.0.0-custom=tgz+https://corretto.aws/downloads/resources/17.0.5.8.1/amazon-corretto-17.0.5.8.1-linux-aarch64.tar.gz -o /jdk
           
+          run: |
+            export MAVEN_OPTS="-Djdk.lang.Process.launchMechanism=vfork"
+            export JAVA_HOME="/jdk"
+            chmod +x ./mvnw
+            ./mvnw -B --show-version -ntp clean package
+
+  Linux-Aarch64-Build-JDK21:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        env:
+          cache-name: cache-m2-repository-${{ runner.os }}-jdk17-aarch64
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-pr-${{ matrix.arch }}-pr-${{ env.cache-name }}-pr-
+      - uses: uraimo/run-on-arch-action@v2.4.0
+        name: Run commands
+        id: runcmd
+        with:
+          arch: aarch64
+          distro: ubuntu18.04
+
+          # Not required, but speeds up builds by storing container images in
+          # a GitHub package registry.
+          githubToken: ${{ github.token }}
+
+          # Mount the .m2/repository
+          dockerRunArgs: |
+            --platform linux/arm64
+            --volume "/home/runner/.m2/repository/:/root/.m2/repository"
+
+          # Install dependencies
+          install: |
+            apt-get update
+            apt-get install -q -y curl gnupg2 autoconf automake libtool make tar git cmake build-essential
+
+            curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | bash && . ~/.jabba/jabba.sh
+            jabba install 21.0.1.12.1-custom=tgz+https://corretto.aws/downloads/resources/21.0.1.12.1/amazon-corretto-21.0.1.12.1-linux-x64.tar.gz -o /jdk
+
           run: |
             export MAVEN_OPTS="-Djdk.lang.Process.launchMechanism=vfork"
             export JAVA_HOME="/jdk"
@@ -551,6 +613,21 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: 17
+          architecture: x64
+      - name: Enable Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@v1.12.0
+      - name: Build with Maven
+        run: mvn -B --show-version -ntp --file pom.xml clean package
+
+  Windows-x86_64-Build-JDK21:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: 21
           architecture: x64
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@v1.12.0

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -253,7 +253,7 @@ jobs:
         id: runcmd
         with:
           arch: aarch64
-          distro: ubuntu18.04
+          distro: ubuntu20.04
 
           # Not required, but speeds up builds by storing container images in
           # a GitHub package registry.
@@ -267,7 +267,10 @@ jobs:
           # Install dependencies
           install: |
             apt-get update
-            apt-get install -q -y curl gnupg2 autoconf automake libtool make tar git cmake build-essential openjdk-21-jdk
+            apt-get install -q -y curl gnupg2 autoconf automake libtool make tar git cmake build-essential
+            
+            curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | bash && . ~/.jabba/jabba.sh
+            jabba install 21.0.1-custom=tgz+https://corretto.aws/downloads/resources/21.0.1.12.1/java-21-amazon-corretto-jdk_21.0.1.12-1_arm64.deb -o /jdk
 
           run: |
             export MAVEN_OPTS="-Djdk.lang.Process.launchMechanism=vfork"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -270,7 +270,7 @@ jobs:
             apt-get install -q -y curl gnupg2 autoconf automake libtool make tar git cmake build-essential
 
             curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | bash && . ~/.jabba/jabba.sh
-            jabba install 21.0.1.12.1-custom=tgz+https://corretto.aws/downloads/resources/21.0.1.12.1/amazon-corretto-21.0.1.12.1-linux-x64.tar.gz -o /jdk
+            jabba install 21.0.1-custom=tgz+https://corretto.aws/downloads/resources/21.0.1.12.1/amazon-corretto-21.0.1.12.1-linux-x64.tar.gz -o /jdk
 
           run: |
             export MAVEN_OPTS="-Djdk.lang.Process.launchMechanism=vfork"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -270,7 +270,7 @@ jobs:
             apt-get install -q -y curl gnupg2 autoconf automake libtool make tar git cmake build-essential
             
             curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | bash && . ~/.jabba/jabba.sh
-            jabba install 21.0.1-custom=tgz+https://corretto.aws/downloads/resources/21.0.1.12.1/java-21-amazon-corretto-jdk_21.0.1.12-1_arm64.deb -o /jdk
+            jabba install 21.0.1-custom=tgz+https://corretto.aws/downloads/resources/21.0.1.12.1/amazon-corretto-21.0.1.12.1-linux-aarch64.tar.gz -o /jdk
 
           run: |
             export MAVEN_OPTS="-Djdk.lang.Process.launchMechanism=vfork"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -247,7 +247,7 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-pr-jdk21-aarch64-pr-${{ env.cache-name }}-pr-
+            ${{ runner.os }}-pr-${{ matrix.arch }}-pr-${{ env.cache-name }}-pr-
       - uses: uraimo/run-on-arch-action@v2.4.0
         name: Run commands
         id: runcmd

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -242,7 +242,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
         env:
-          cache-name: cache-m2-repository-${{ runner.os }}-jdk17-aarch64
+          cache-name: cache-m2-repository-${{ runner.os }}-jdk21-aarch64
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -267,10 +267,7 @@ jobs:
           # Install dependencies
           install: |
             apt-get update
-            apt-get install -q -y curl gnupg2 autoconf automake libtool make tar git cmake build-essential
-
-            curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | bash && . ~/.jabba/jabba.sh
-            jabba install 21.0.1-custom=tgz+https://corretto.aws/downloads/resources/21.0.1.12.1/amazon-corretto-21.0.1.12.1-linux-x64.tar.gz -o /jdk
+            apt-get install -q -y curl gnupg2 autoconf automake libtool make tar git cmake build-essential openjdk-21-jdk
 
           run: |
             export MAVEN_OPTS="-Djdk.lang.Process.launchMechanism=vfork"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -247,7 +247,7 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-pr-${{ matrix.arch }}-pr-${{ env.cache-name }}-pr-
+            ${{ runner.os }}-pr-jdk21-aarch64-pr-${{ env.cache-name }}-pr-
       - uses: uraimo/run-on-arch-action@v2.4.0
         name: Run commands
         id: runcmd

--- a/docker/Dockerfile21.centos6
+++ b/docker/Dockerfile21.centos6
@@ -1,0 +1,45 @@
+FROM gatlingcorp/centos:6-gcc5
+
+RUN rm -vf /usr/lib64/libstdc++.so.6.0.24-gdb.py
+
+RUN yum -y install \
+            git 
+
+RUN export java_version=amazon-corretto@21.0.1.12.1 && \
+    export JAVA_VERSION=$java_version && \
+    curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | JABBA_COMMAND="install 21.0.1.12.1-custom=tgz+https://corretto.aws/downloads/resources/21.0.1.12.1/amazon-corretto-21.0.1.12.1-linux-x64.tar.gz -o /jdk" bash && \
+    echo 'export JAVA_HOME="/jdk"' >> ~/.bashrc && \
+    echo 'PATH=/jdk/bin:$PATH' >> ~/.bashrc 
+
+ENV JAVA_HOME "/jdk"
+ENV PATH      "/jdk/bin:$PATH"
+
+RUN mkdir -p  /workspace
+
+RUN mkdir -p /opt && \
+    cd /opt  && \
+    wget --no-verbose https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.tar.gz && \
+    tar xzf apache-maven-3.8.6-bin.tar.gz && \
+    ln -s apache-maven-3.8.6 maven && \
+    ln -s /opt/maven/bin/mvn /usr/bin/mvn
+
+RUN cd /opt && \
+    wget --no-verbose https://github.com/Kitware/CMake/releases/download/v3.20.1/cmake-3.20.1-linux-x86_64.sh && \
+    chmod a+x cmake-3.20.1-linux-x86_64.sh && \
+    yes | ./cmake-3.20.1-linux-x86_64.sh  
+
+ENV MAVEN_HOME 	"/opt/maven"
+ENV PATH 	"/opt/maven/bin:$PATH"
+ENV PATH 	"/opt/cmake-3.20.1-linux-x86_64/bin:$PATH" 
+
+RUN mkdir /workspace/Brotli4j
+RUN cd /workspace/Brotli4j
+
+RUN echo "/jdk/lib/amd64" >> /etc/ld.so.conf
+RUN echo "/jdk/jre/lib/amd64/" >> /etc/ld.so.conf
+
+RUN ldconfig
+
+RUN echo "export MAVEN_HOME=/opt/maven" >> ~/.bashrc
+RUN echo "export PATH=/opt/maven/bin:\$PATH  " >>  ~/.bashrc
+RUN echo "export PATH=/opt/cmake-3.20.1-linux-x86_64/bin:\$PATH " >>  ~/.bashrc

--- a/docker/Dockerfile21.centos6
+++ b/docker/Dockerfile21.centos6
@@ -5,9 +5,9 @@ RUN rm -vf /usr/lib64/libstdc++.so.6.0.21-gdb.py
 RUN yum -y install \
             git 
 
-RUN export java_version=amazon-corretto@21.0.1.12.1 && \
+RUN export java_version=amazon-corretto@21.0.1 && \
     export JAVA_VERSION=$java_version && \
-    curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | JABBA_COMMAND="install 21.0.1.12.1-custom=tgz+https://corretto.aws/downloads/resources/21.0.1.12.1/amazon-corretto-21.0.1.12.1-linux-x64.tar.gz -o /jdk" bash && \
+    curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | JABBA_COMMAND="install 21.0.1-custom=tgz+https://corretto.aws/downloads/resources/21.0.1.12.1/amazon-corretto-21.0.1.12.1-linux-x64.tar.gz -o /jdk" bash && \
     echo 'export JAVA_HOME="/jdk"' >> ~/.bashrc && \
     echo 'PATH=/jdk/bin:$PATH' >> ~/.bashrc 
 

--- a/docker/Dockerfile21.centos6
+++ b/docker/Dockerfile21.centos6
@@ -1,6 +1,6 @@
 FROM gatlingcorp/centos:6-gcc5
 
-RUN rm -vf /usr/lib64/libstdc++.so.6.0.24-gdb.py
+RUN rm -vf /usr/lib64/libstdc++.so.6.0.21-gdb.py
 
 RUN yum -y install \
             git 

--- a/docker/docker-compose21.yml
+++ b/docker/docker-compose21.yml
@@ -1,0 +1,25 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: brotli4j:default
+    build:
+      context: .
+      dockerfile: Dockerfile21.centos6
+
+  common: &common
+    image: brotli4j:default
+    depends_on: [ runtime-setup ]
+    volumes:
+      - ~/.m2:/root/.m2
+      - ..:/code
+    working_dir: /code
+
+  build:
+    <<: *common
+    command: /bin/bash -cl "mvn -B --show-version -ntp --file pom.xml clean package"
+
+  shell:
+    <<: *common
+    entrypoint: /bin/bash


### PR DESCRIPTION
Motivation:

JDK 21 is the new LTS and we should test Brotli4j on it for compatibility.

Modification:

Added JDK 21 builds.

Result:

JDK 21 CI builds.
