### PR TITLE
Add ppc64le architecture support

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -384,6 +384,82 @@ jobs:
             chmod +x ./mvnw
             ./mvnw -B --show-version -ntp clean package
 
+  Linux-ppc64le-Build-JDK8:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        env:
+          cache-name: cache-m2-repository-${{ runner.os }}-jdk8-ppc64le
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-pr-${{ matrix.arch }}-pr-${{ env.cache-name }}-pr-
+      - uses: uraimo/run-on-arch-action@v2.3.0
+        name: Run commands
+        id: runcmd
+        with:
+          arch: ppc64le
+          distro: ubuntu18.04
+
+          # Not required, but speeds up builds by storing container images in
+          # a GitHub package registry.
+          githubToken: ${{ github.token }}
+
+          # Mount the .m2/repository
+          dockerRunArgs: |
+            --platform linux/ppc64le
+            --volume "/home/runner/.m2/repository/:/root/.m2/repository"
+          # Install dependencies
+          install: |
+            apt-get update
+            apt-get install -q -y curl gnupg2 autoconf automake libtool make tar git cmake build-essential openjdk-8-jdk
+          
+          run: |
+            chmod +x ./mvnw
+            ./mvnw -B -ntp clean package
+      - name: Upload the build
+        uses: actions/upload-artifact@v3
+        with:
+          name: Linux-ppc64le-Build-JDK8
+          path: /home/runner/work/Brotli4j/
+
+  Linux-ppc64le-Build-JDK11:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        env:
+          cache-name: cache-m2-repository-${{ runner.os }}-jdk11-ppc64le
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-pr-${{ matrix.arch }}-pr-${{ env.cache-name }}-pr-
+      - uses: uraimo/run-on-arch-action@v2.3.0
+        name: Run commands
+        id: runcmd
+        with:
+          arch: ppc64le
+          distro: ubuntu18.04
+
+          # Not required, but speeds up builds by storing container images in
+          # a GitHub package registry.
+          githubToken: ${{ github.token }}
+
+          # Mount the .m2/repository
+          dockerRunArgs: |
+            --platform linux/ppc64le
+            --volume "/home/runner/.m2/repository/:/root/.m2/repository"
+          # Install dependencies
+          install: |
+            apt-get update
+            apt-get install -q -y curl gnupg2 autoconf automake libtool make tar git cmake build-essential openjdk-11-jdk
+          run: |
+            chmod +x ./mvnw
+            ./mvnw -B -ntp clean package          
+
   Linux-riscv64-Build-JDK11:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Brotli4j provides Brotli compression and decompression for Java.
 | Linux (Ubuntu 18.04)          |   Aarch64    |         JDK 1.8, JDK 11, JDK 17 |
 | Linux (Ubuntu 18.04)          |    ARMv7     |                 JDK 1.8, JDK 11 |
 | Linux (Ubuntu 18.04)          |    s390x     |                 JDK 1.8, JDK 11 |
+| Linux (Ubuntu 18.04)          |    ppc64le     |                 JDK 1.8, JDK 11 |
 | Linux (Ubuntu 20.04)          |   RISC-V64   | JDK 1.8, JDK 11, JDK 17, JDK 21 |
 | macOS (Catalina)              |     x64      |         JDK 1.8, JDK 11, JDK 17 |
 | macOS (Catalina)              |   Aarch64    |         JDK 1.8, JDK 11, JDK 17 |

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -66,6 +66,11 @@
             </dependency>
             <dependency>
                 <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-linux-ppc64le</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
                 <artifactId>native-linux-riscv64</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/brotli4j/pom.xml
+++ b/brotli4j/pom.xml
@@ -77,6 +77,23 @@
         </profile>
 
         <profile>
+            <id>linux-ppc64le</id>
+            <activation>
+                <os>
+                    <family>Linux</family>
+                    <arch>ppc64le</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.aayushatharva.brotli4j</groupId>
+                    <artifactId>native-linux-ppc64le</artifactId>
+                    <version>${project.parent.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
             <id>linux-aarch64</id>
             <activation>
                 <os>

--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/Brotli4jLoader.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/Brotli4jLoader.java
@@ -128,6 +128,8 @@ public class Brotli4jLoader {
                 return "linux-armv7";
             } else if ("s390x".equalsIgnoreCase(archName)) {
                 return "linux-s390x";
+            } else if ("ppc64le".equalsIgnoreCase(archName)) {
+                return "linux-ppc64le";
             } else if ("riscv64".equalsIgnoreCase(archName)) {
                 return "linux-riscv64";
             }

--- a/natives/linux-ppc64le/build.sh
+++ b/natives/linux-ppc64le/build.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+CURPATH=$(pwd)
+TARGET_CLASSES_PATH="target/classes/lib/linux-ppc64le"
+TARGET_PATH="target"
+
+exitWithError() {
+  cd ${CURPATH}
+  echo "*** An error occurred. Please check log messages. ***"
+  exit $1
+}
+
+mkdir -p "$TARGET_CLASSES_PATH"
+
+cd "$TARGET_PATH"
+cmake ../../../ || exitWithError $?
+make || exitWithError $?
+rm -f "$CURPATH/${TARGET_CLASSES_PATH}/libbrotli.so"
+cp "./libbrotli.so" "$CURPATH/${TARGET_CLASSES_PATH}" || exitWithError $?
+
+cd "${CURPATH}"

--- a/natives/linux-ppc64le/pom.xml
+++ b/natives/linux-ppc64le/pom.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2020-2023, Aayush Atharva
+
+  Brotli4j licenses this file to you under the
+  Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>natives</artifactId>
+        <groupId>com.aayushatharva.brotli4j</groupId>
+        <version>1.12.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>native-linux-ppc64le</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <javaModuleName>com.aayushatharva.brotli4j.linux.ppc64le</javaModuleName>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.0.0.RC2</version>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <jvmVersion>9</jvmVersion>
+                            <module>
+                                <moduleInfoSource>
+                                    module ${javaModuleName} {
+                                    requires com.aayushatharva.brotli4j.service;
+                                    exports ${javaModuleName} to com.aayushatharva.brotli4j;
+                                    provides com.aayushatharva.brotli4j.service.BrotliNativeProvider with
+                                    ${javaModuleName}.NativeLoader;
+                                    }
+                                </moduleInfoSource>
+                            </module>
+                            <jdepsExtraArgs>
+                                <arg>--multi-release</arg>
+                                <arg>9</arg>
+                            </jdepsExtraArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>linux-ppc64le</id>
+            <activation>
+                <os>
+                    <family>Linux</family>
+                    <arch>ppc64le</arch>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <executions>
+                            <execution>
+                                <id>build-native</id>
+                                <phase>process-classes</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>/bin/bash</executable>
+                                    <arguments>
+                                        <argument>build.sh</argument>
+                                    </arguments>
+                                    <workingDirectory>${project.basedir}</workingDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>release</id>
+            <build>
+                <resources>
+                    <resource>
+                        <directory>resources</directory>
+                    </resource>
+                </resources>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/natives/linux-ppc64le/src/main/java/com/aayushatharva/brotli4j/linux/ppc64le/NativeLoader.java
+++ b/natives/linux-ppc64le/src/main/java/com/aayushatharva/brotli4j/linux/ppc64le/NativeLoader.java
@@ -1,0 +1,30 @@
+/*
+ *    Copyright (c) 2020-2023, Aayush Atharva
+ *
+ *    Brotli4j licenses this file to you under the
+ *    Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.aayushatharva.brotli4j.linux.ppc64le;
+
+import com.aayushatharva.brotli4j.service.BrotliNativeProvider;
+
+/**
+ * Service class to access the native lib in a JPMS context
+ */
+public class NativeLoader implements BrotliNativeProvider {
+
+    @Override
+    public String platformName() {
+        return "linux-ppc64le";
+    }
+}

--- a/natives/linux-x86_64/pom.xml
+++ b/natives/linux-x86_64/pom.xml
@@ -31,6 +31,7 @@
 
     <properties>
         <javaModuleName>com.aayushatharva.brotli4j.linux.s390x</javaModuleName>
+        <javaModuleName>com.aayushatharva.brotli4j.linux.ppc64le</javaModuleName>
     </properties>
 
     <build>

--- a/natives/pom.xml
+++ b/natives/pom.xml
@@ -32,6 +32,7 @@
         <module>linux-aarch64</module>
         <module>linux-armv7</module>
         <module>linux-s390x</module>
+        <module>linux-ppc64le</module>
         <module>linux-riscv64</module>
         <module>windows-x86_64</module>
         <module>osx-x86_64</module>
@@ -71,6 +72,19 @@
             </activation>
             <modules>
                 <module>linux-s390x</module>
+            </modules>
+        </profile>
+
+        <profile>
+            <id>linux-ppc64le</id>
+            <activation>
+                <os>
+                    <family>Linux</family>
+                    <arch>ppc64le</arch>
+                </os>
+            </activation>
+            <modules>
+                <module>linux-ppc64le</module>
             </modules>
         </profile>
 
@@ -159,6 +173,7 @@
                 <module>linux-aarch64</module>
                 <module>linux-armv7</module>
                 <module>linux-s390x</module>
+                <module>linux-ppc64le</module>
                 <module>linux-riscv64</module>
                 <module>windows-x86_64</module>
                 <module>osx-x86_64</module>


### PR DESCRIPTION
Motivation:
This patch adds support for linux-ppc64le.

Modification:
Added ppc64le native module

Result:
ppc64le arch support