### PR TITLE
Update Netty 4.1.104.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-buffer</artifactId>
-            <version>4.1.100.Final</version>
+            <version>4.1.104.Final</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
Motivation:
The latest version of Netty is 4.1.104.Final. And we should upgrade to it.

Modification:
Updated Netty to 4.1.104.Final

Result:
Latest Netty version
