### PR TITLE
Fix `all/pom.xml` formatting

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -39,7 +39,7 @@
                 <artifactId>brotli4j</artifactId>
                 <version>${project.version}</version>
             </dependency>
-			<dependency>
+	    <dependency>
                 <groupId>com.aayushatharva.brotli4j</groupId>
                 <artifactId>service</artifactId>
                 <version>${project.version}</version>


### PR DESCRIPTION
Motivation:
`all/pom.xml` had formatting issues which should be fixed.

Modification:
Fixed `all/pom.xml` formatting.

Result:
Clean `all/pom.xml` formatting.
