### PR TITLE
Encoder wrong length during `push` op

### DIFF
--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/encoder/Encoder.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/encoder/Encoder.java
@@ -70,7 +70,7 @@ public class Encoder {
         int totalOutputSize = 0;
         try {
             encoder.getInputBuffer().put(data, offset, length);
-            encoder.push(EncoderJNI.Operation.FINISH, data.length);
+            encoder.push(EncoderJNI.Operation.FINISH, length);
             while (true) {
                 if (!encoder.isSuccess()) {
                     throw new IOException("encoding failed");


### PR DESCRIPTION
Motivation:

Currently, the Java wrapper Encoder passes byte array length for finishing data encoding. This is ideal when the encoder is used with offset 0 and full length is passed but for cases where offset is passed and length is also specified, it leads to encoded data corruption.

Modification:
Instead of passing byte array length to the `push` method, we will now pass `length` directly.

Result:
Error-free encoding