### PR TITLE
Fix Module Name for `linux-x86_64`

### DIFF
--- a/natives/linux-x86_64/pom.xml
+++ b/natives/linux-x86_64/pom.xml
@@ -30,8 +30,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <javaModuleName>com.aayushatharva.brotli4j.linux.s390x</javaModuleName>
-        <javaModuleName>com.aayushatharva.brotli4j.linux.ppc64le</javaModuleName>
+        <javaModuleName>com.aayushatharva.brotli4j.linux.x86_64</javaModuleName>
     </properties>
 
     <build>


### PR DESCRIPTION
Motivation:
Module name for `linux-x86_64` native was broken,

Modification:
Updated correct Java Module name for `linux-x86_64`

Result:
JPMS works again
