### PR TITLE
Make Encoder types public

### DIFF
--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/encoder/Encoder.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/encoder/Encoder.java
@@ -35,7 +35,7 @@ public class Encoder {
      * @param params          encoding parameters
      * @param inputBufferSize read buffer size
      */
-    Encoder(WritableByteChannel destination, Parameters params, int inputBufferSize) throws IOException {
+    public Encoder(WritableByteChannel destination, Parameters params, int inputBufferSize) throws IOException {
         if (inputBufferSize <= 0) {
             throw new IllegalArgumentException("buffer size must be positive");
         }

--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/encoder/EncoderJNI.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/encoder/EncoderJNI.java
@@ -23,7 +23,7 @@ public class EncoderJNI {
     private static native ByteBuffer nativePrepareDictionary(ByteBuffer dictionary, long type);
     private static native void nativeDestroyDictionary(ByteBuffer dictionary);
 
-    enum Operation {
+    public enum Operation {
         PROCESS,
         FLUSH,
         FINISH


### PR DESCRIPTION
Motivation:

To allow for alternative Encoder use, make Encoder and EncoderJNI.Operation public.

Modification:

Made Encoder and EncoderJNI.Operation public.

Result:

Fixes #144

