### PR TITLE
Upgrade Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-buffer</artifactId>
-            <version>4.1.104.Final</version>
+            <version>4.1.111.Final</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.10.0</version>
+            <version>5.10.3</version>
             <scope>test</scope>
         </dependency>
 
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.10.0</version>
+            <version>5.10.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Motivation:
We should upgrade our dependencies to the latest version to ensure compatibility.

Modification:
Upgraded Netty to [4.1.111.Final](https://mvnrepository.com/artifact/io.netty/netty-all/4.1.111.Final) and JUnit to [5.10.3](https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api/5.10.3).

Result:
Up-to-date dependencies

