### PR TITLE
Upgrade to Netty 4.1.112.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-buffer</artifactId>
-            <version>4.1.111.Final</version>
+            <version>4.1.112.Final</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
Motivation:
Netty 4.1.112.Final is available and we should use it.

Modification:
Updated to Netty 4.1.112.Final

Result:
Up-to-date Netty version

