### PR TITLE
Use docker compose plugin

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -77,7 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: build centos6
-        run: docker compose -f docker/docker compose.yml run build
+        run: docker compose -f docker/docker-compose.yml run build
       - name: Upload the build
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -77,7 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: build centos6
-        run: docker-compose -f docker/docker-compose.yml run build
+        run: docker compose -f docker/docker compose.yml run build
       - name: Upload the build
         uses: actions/upload-artifact@v3
         with:
@@ -89,21 +89,21 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: build centos6
-        run: docker-compose -f docker/docker-compose11.yml run build
+        run: docker compose -f docker/docker-compose11.yml run build
 
   Linux-x86_64-Build-JDK17:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: build centos6
-        run: docker-compose -f docker/docker-compose17.yml run build
+        run: docker compose -f docker/docker-compose17.yml run build
 
   Linux-x86_64-Build-JDK21:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: build centos6
-        run: docker-compose -f docker/docker-compose21.yml run build
+        run: docker compose -f docker/docker-compose21.yml run build
 
   Linux-Aarch64-Build-JDK8:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Motivation:
`docker-compose` is no longer available and we should use `docker compose` plugin now.

Modification:
Updated workflows to use `docker compose` plugin

Result:
Build working again
