### PR TITLE
Improve encoder parameter configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ public class Example {
         FileInputStream inFile = new FileInputStream(filePath);
         FileOutputStream outFile = new FileOutputStream(filePath + ".br");
 
-        Encoder.Parameters params = new Encoder.Parameters().setQuality(4);
+        Encoder.Parameters params = new Encoder.Parameters.create(4);
 
         BrotliOutputStream brotliOutputStream = new BrotliOutputStream(outFile, params);
 

--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/encoder/Encoder.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/encoder/Encoder.java
@@ -265,10 +265,34 @@ public class Encoder {
         public Parameters() {
         }
 
-        private Parameters(Parameters other) {
-            this.quality = other.quality;
-            this.lgwin = other.lgwin;
-            this.mode = other.mode;
+        /**
+         * @param quality compression quality, or -1 for default
+         * @return this instance
+         */
+        public static Parameters create(int quality) {
+            return create(quality, -1);
+        }
+
+        /**
+         * @param quality compression quality, or -1 for default
+         * @param lgwin log2(LZ window size), or -1 for default
+         * @return this instance
+         */
+        public static Parameters create(int quality, int lgwin) {
+            return create(quality, lgwin, null);
+        }
+
+        /**
+         * @param quality compression quality, or -1 for default
+         * @param lgwin log2(LZ window size), or -1 for default
+         * @param mode compression mode, or {@code null} for default
+         * @return this instance
+         */
+        public static Parameters create(int quality, int lgwin, Mode mode) {
+            return new Parameters()
+                    .setQuality(quality)
+                    .setWindow(lgwin)
+                    .setMode(mode);
         }
 
         /**

--- a/brotli4j/src/test/java/com/aayushatharva/brotli4j/encoder/EncoderTest.java
+++ b/brotli4j/src/test/java/com/aayushatharva/brotli4j/encoder/EncoderTest.java
@@ -47,7 +47,7 @@ class EncoderTest {
 
     @Test
     void compressWithQuality() throws IOException {
-        assertArrayEquals(compressedData, Encoder.compress("Meow".getBytes(), new Encoder.Parameters().setQuality(6)));
+        assertArrayEquals(compressedData, Encoder.compress("Meow".getBytes(), Encoder.Parameters.create(6)));
     }
 
     @Test


### PR DESCRIPTION
**Motivation:**
Hello,

Currently, configuring `Encoder.Parameters` requires the following two steps:

1. Create an `Encoder.Parameters` object.
2. Use setter methods like `quality`, `lgwin`, or `mode` to configure it.
This approach can be unnecessarily complex and may lack clarity.


**Modification:**

In this PR, I propose adding static methods to configure `Encoder.Parameters` without explicitly creating an object. 
This makes the configuration process more intuitive and concise.

**Result:**
I believe this change will enhance code usability. 
I would appreciate your review!

Thanks.
