### PR TITLE
Make Dependabot less noisy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,21 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
   - package-ecosystem: "maven"
-    directories:
-      - "/"
+    directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
+    open-pull-requests-limit: 1
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+
   - package-ecosystem: "github-actions"
-    directories:
-      - "/"
+    directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
+    open-pull-requests-limit: 1
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Motivation:
Dependabot creates lots of PR at once, and it gets very noisy. Also, JUnit requires both `engine` and `api` to have same version but also breaks apart due to that.

Modification:
Run Dependabot monthly, limit the maximum PR to one for each ecosystem, and `groups` multiple PRs together.

Result:
Less noisy and clean dependabot updates
