### PR TITLE
Efficiency: Let thread do other tasks as long encoder/decoder is busy

### DIFF
--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/decoder/BrotliInputStream.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/decoder/BrotliInputStream.java
@@ -82,6 +82,7 @@ public class BrotliInputStream extends InputStream {
             if (decoded != 0) {
                 break;
             }
+            Thread.yield();
         }
 
         if (decoded == -1) {
@@ -105,7 +106,10 @@ public class BrotliInputStream extends InputStream {
         }
         int result = 0;
         while (len > 0) {
-            int limit = Math.min(len, decoder.buffer.remaining());
+            int limit;
+            while ((limit = Math.min(len, decoder.buffer.remaining())) == 0) {
+                Thread.yield();
+            }
             decoder.buffer.get(b, off, limit);
             off += limit;
             len -= limit;


### PR DESCRIPTION
Motivation:

Busy loops are blocking valuable threads, so other tasks are blocked while the current task spins waiting. This reduces concurrency without a need, hence makes inefficient use of the existing hardware.

Modification:

Using `Thread.yield()` in all busy waiting loops.

Result:

Other tasks are allowed to run while encode / decoder is busy.