### PR TITLE
Fix incorrect usage of Encoder.Parameters in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ public class Example {
         FileInputStream inFile = new FileInputStream(filePath);
         FileOutputStream outFile = new FileOutputStream(filePath + ".br");
 
-        Encoder.Parameters params = new Encoder.Parameters().setQuality(4);
+        Encoder.Parameters params = Encoder.Parameters.create(4);
 
         BrotliOutputStream brotliOutputStream = new BrotliOutputStream(outFile, params);
 


### PR DESCRIPTION
Motivation:

The current README contains an invalid example in the “Compressing a stream” section. It uses 
`new Encoder.Parameters.create(4);`, which does not exist in the actual API.

Modification:

I updated the README to replace:
````
Encoder.Parameters params = new Encoder.Parameters.create(4);
````
with the correct, working usage:
````
Encoder.Parameters params = new Encoder.Parameters().setQuality(4);
````

Result:

Fixes incorrect documentation in the README.
