### PR TITLE
Release v1.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For maven, the natives will
 <dependency>
     <groupId>com.aayushatharva.brotli4j</groupId>
     <artifactId>brotli4j</artifactId>
-    <version>1.19.0</version>
+    <version>1.20.0</version>
 </dependency>
 ```
 
@@ -72,8 +72,8 @@ To add the dependency, use:
 
 ```kotlin
 dependencies {
-    implementation("com.aayushatharva.brotli4j:brotli4j:1.19.0")
-    runtimeOnly("com.aayushatharva.brotli4j:natives:1.19.0")
+    implementation("com.aayushatharva.brotli4j:brotli4j:1.20.0")
+    runtimeOnly("com.aayushatharva.brotli4j:natives:1.20.0")
 }
 ```
 
@@ -145,7 +145,7 @@ If you are using the shadow gradle plugin, then in your `build.gradle.kts` inclu
 
 ```kotlin
 dependencies {
-    shaded("com.aayushatharva.brotli4j:natives:1.19.0")
+    shaded("com.aayushatharva.brotli4j:natives:1.20.0")
 }
 
 tasks {
@@ -215,7 +215,7 @@ val shaded by configurations.registering {
 }
 
 dependencies {
-    shaded("com.aayushatharva.brotli4j:natives:1.19.0")
+    shaded("com.aayushatharva.brotli4j:natives:1.20.0")
 }
 
 tasks {
@@ -352,7 +352,7 @@ If you are using the shadow gradle plugin, then in your `build.gradle` include:
 
 ```kotlin
 dependencies {
-    shaded("com.aayushatharva.brotli4j:natives:1.19.0")
+    shaded("com.aayushatharva.brotli4j:natives:1.20.0")
 }
 
 tasks {
@@ -418,7 +418,7 @@ configurations.register("shaded") {
 }
 
 dependencies {
-    shaded("com.aayushatharva.brotli4j:natives:1.19.0")
+    shaded("com.aayushatharva.brotli4j:natives:1.20.0")
 }
 
 tasks {

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.aayushatharva.brotli4j</groupId>
         <artifactId>brotli4j-parent</artifactId>
-        <version>1.19.0</version>
+        <version>1.20.0</version>
     </parent>
 
     <artifactId>all</artifactId>

--- a/brotli4j/pom.xml
+++ b/brotli4j/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>brotli4j-parent</artifactId>
         <groupId>com.aayushatharva.brotli4j</groupId>
-        <version>1.19.0</version>
+        <version>1.20.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/natives/linux-aarch64/pom.xml
+++ b/natives/linux-aarch64/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>natives</artifactId>
         <groupId>com.aayushatharva.brotli4j</groupId>
-        <version>1.19.0</version>
+        <version>1.20.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/natives/linux-armv7/pom.xml
+++ b/natives/linux-armv7/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>natives</artifactId>
         <groupId>com.aayushatharva.brotli4j</groupId>
-        <version>1.19.0</version>
+        <version>1.20.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/natives/linux-ppc64le/pom.xml
+++ b/natives/linux-ppc64le/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>natives</artifactId>
         <groupId>com.aayushatharva.brotli4j</groupId>
-        <version>1.19.0</version>
+        <version>1.20.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/natives/linux-riscv64/pom.xml
+++ b/natives/linux-riscv64/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>natives</artifactId>
         <groupId>com.aayushatharva.brotli4j</groupId>
-        <version>1.19.0</version>
+        <version>1.20.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/natives/linux-s390x/pom.xml
+++ b/natives/linux-s390x/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>natives</artifactId>
         <groupId>com.aayushatharva.brotli4j</groupId>
-        <version>1.19.0</version>
+        <version>1.20.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/natives/linux-x86_64/pom.xml
+++ b/natives/linux-x86_64/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>natives</artifactId>
         <groupId>com.aayushatharva.brotli4j</groupId>
-        <version>1.19.0</version>
+        <version>1.20.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/natives/osx-aarch64/pom.xml
+++ b/natives/osx-aarch64/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>natives</artifactId>
         <groupId>com.aayushatharva.brotli4j</groupId>
-        <version>1.19.0</version>
+        <version>1.20.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/natives/osx-x86_64/pom.xml
+++ b/natives/osx-x86_64/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>natives</artifactId>
         <groupId>com.aayushatharva.brotli4j</groupId>
-        <version>1.19.0</version>
+        <version>1.20.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/natives/pom.xml
+++ b/natives/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.aayushatharva.brotli4j</groupId>
         <artifactId>brotli4j-parent</artifactId>
-        <version>1.19.0</version>
+        <version>1.20.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/natives/windows-aarch64/pom.xml
+++ b/natives/windows-aarch64/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>natives</artifactId>
         <groupId>com.aayushatharva.brotli4j</groupId>
-        <version>1.19.0</version>
+        <version>1.20.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/natives/windows-x86_64/pom.xml
+++ b/natives/windows-x86_64/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>natives</artifactId>
         <groupId>com.aayushatharva.brotli4j</groupId>
-        <version>1.19.0</version>
+        <version>1.20.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>com.aayushatharva.brotli4j</groupId>
     <artifactId>brotli4j-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.19.0</version>
+    <version>1.20.0</version>
 
     <name>Brotli4j</name>
     <description>Brotli4j provides Brotli compression and decompression for Java.</description>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.aayushatharva.brotli4j</groupId>
         <artifactId>brotli4j-parent</artifactId>
-        <version>1.19.0</version>
+        <version>1.20.0</version>
     </parent>
 
     <artifactId>service</artifactId>


### PR DESCRIPTION
Motivation:
Brotli4j v1.19.0 was broken because CI compiled Windows x86_64 binaries along with Windows arm64 binaries together in one arm64 job. And when all files were merged, it replaced actual Windows x86_64 binaries with arm64.

This is an emergency fix; more robust pipeline will be part of next release.

Modification:
Manual release of Brotli4j v1.20.0 with correct Windows arm64 and x86_64 binaries.

Result:
Fixes #226
