### PR TITLE
Add per-pull output cap to decoder

### DIFF
--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/common/annotations/Local.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/common/annotations/Local.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
  * represents code which created locally and not in sync with
  * Google Brotli upstream repository.
  */
-@Target({ElementType.FIELD, ElementType.TYPE, ElementType.METHOD})
+@Target({ElementType.FIELD, ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR})
 @Retention(RetentionPolicy.SOURCE)
 public @interface Local {
 }

--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/decoder/BrotliDecoderChannel.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/decoder/BrotliDecoderChannel.java
@@ -5,6 +5,7 @@
 */
 package com.aayushatharva.brotli4j.decoder;
 
+import com.aayushatharva.brotli4j.common.annotations.Local;
 import com.aayushatharva.brotli4j.common.annotations.Upstream;
 
 import java.io.IOException;
@@ -43,6 +44,19 @@ public class BrotliDecoderChannel extends Decoder implements ReadableByteChannel
      */
     public BrotliDecoderChannel(ReadableByteChannel source, int bufferSize) throws IOException {
         super(source, bufferSize);
+    }
+
+    /**
+     * Creates a BrotliDecoderChannel with a per-pull output cap.
+     *
+     * @param source             underlying source
+     * @param bufferSize         intermediate buffer size
+     * @param maxOutputChunkSize per-pull output cap in bytes; {@code 0} for no cap
+     * @throws IOException If any failure during initialization
+     */
+    @Local
+    public BrotliDecoderChannel(ReadableByteChannel source, int bufferSize, int maxOutputChunkSize) throws IOException {
+        super(source, bufferSize, maxOutputChunkSize);
     }
 
     @Override

--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/decoder/BrotliInputStream.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/decoder/BrotliInputStream.java
@@ -5,6 +5,7 @@
 */
 package com.aayushatharva.brotli4j.decoder;
 
+import com.aayushatharva.brotli4j.common.annotations.Local;
 import com.aayushatharva.brotli4j.common.annotations.Upstream;
 
 import java.io.IOException;
@@ -33,7 +34,21 @@ public class BrotliInputStream extends InputStream {
      */
     public BrotliInputStream(InputStream source, int bufferSize)
             throws IOException {
-        this.decoder = new Decoder(Channels.newChannel(source), bufferSize);
+        this(source, bufferSize, 0);
+    }
+
+    /**
+     * Creates a BrotliInputStream with a per-pull output cap.
+     *
+     * @param source             underlying source
+     * @param bufferSize         intermediate buffer size
+     * @param maxOutputChunkSize per-pull output cap in bytes; {@code 0} for no cap
+     * @throws IOException If any failure during initialization
+     */
+    @Local
+    public BrotliInputStream(InputStream source, int bufferSize, int maxOutputChunkSize)
+            throws IOException {
+        this.decoder = new Decoder(Channels.newChannel(source), bufferSize, maxOutputChunkSize);
     }
 
     /**

--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/decoder/Decoder.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/decoder/Decoder.java
@@ -36,6 +36,20 @@ public class Decoder implements AutoCloseable {
      */
     public Decoder(ReadableByteChannel source, int inputBufferSize)
             throws IOException {
+        this(source, inputBufferSize, 0);
+    }
+
+    /**
+     * Creates a Decoder wrapper with a per-pull output cap.
+     *
+     * @param source             underlying source
+     * @param inputBufferSize    read buffer size
+     * @param maxOutputChunkSize per-pull output cap in bytes; {@code 0} for no cap
+     * @throws IOException If any failure during initialization
+     */
+    @Local
+    public Decoder(ReadableByteChannel source, int inputBufferSize, int maxOutputChunkSize)
+            throws IOException {
         if (inputBufferSize <= 0) {
             throw new IllegalArgumentException("buffer size must be positive");
         }
@@ -43,7 +57,7 @@ public class Decoder implements AutoCloseable {
             throw new NullPointerException("source can not be null");
         }
         this.source = source;
-        this.decoder = new DecoderJNI.Wrapper(inputBufferSize);
+        this.decoder = new DecoderJNI.Wrapper(inputBufferSize, maxOutputChunkSize);
     }
 
     /**
@@ -55,6 +69,20 @@ public class Decoder implements AutoCloseable {
      */
     @Local
     public static DirectDecompress decompress(byte[] data) throws IOException {
+        return decompress(data, 0);
+    }
+
+    /**
+     * Decodes the given data buffer, failing if decompressed output would
+     * exceed {@code maxOutputSize} bytes. Use to mitigate decompression bombs.
+     *
+     * @param data          byte array of data to be decoded
+     * @param maxOutputSize cap on total decompressed bytes; {@code 0} for no cap
+     * @return {@link DirectDecompress} instance
+     * @throws IOException If an error occurs during decoding, or output exceeds {@code maxOutputSize}
+     */
+    @Local
+    public static DirectDecompress decompress(byte[] data, int maxOutputSize) throws IOException {
         DecoderJNI.Wrapper decoder = new DecoderJNI.Wrapper(data.length);
         ArrayList<byte[]> output = new ArrayList<>();
         int totalOutputSize = 0;
@@ -68,11 +96,17 @@ public class Decoder implements AutoCloseable {
                         break;
 
                     case NEEDS_MORE_OUTPUT:
-                        ByteBuffer buffer = decoder.pull();
+                        ByteBuffer buffer = maxOutputSize > 0
+                                ? decoder.pull(Math.max(1, maxOutputSize - totalOutputSize))
+                                : decoder.pull();
                         byte[] chunk = new byte[buffer.remaining()];
                         buffer.get(chunk);
                         output.add(chunk);
                         totalOutputSize += chunk.length;
+                        if (maxOutputSize > 0 && totalOutputSize >= maxOutputSize
+                                && decoder.getStatus() == DecoderJNI.Status.NEEDS_MORE_OUTPUT) {
+                            throw new IOException("decompressed size exceeds maximum size " + maxOutputSize);
+                        }
                         break;
 
                     case NEEDS_MORE_INPUT:
@@ -235,6 +269,72 @@ public class Decoder implements AutoCloseable {
                         // Give decoder a chance to process the remaining of the buffered byte.
                         decoder.push(0);
                         // If decoder still needs input, this means that stream is truncated.
+                        if (decoder.getStatus() == DecoderJNI.Status.NEEDS_MORE_INPUT) {
+                            throw new IOException("corrupted input");
+                        }
+                        break;
+
+                    default:
+                        throw new IOException("corrupted input");
+                }
+            }
+        } finally {
+            decoder.destroy();
+        }
+        if (output.size() == 1) {
+            return output.get(0);
+        }
+        byte[] result = new byte[totalOutputSize];
+        int resultOffset = 0;
+        for (byte[] chunk : output) {
+            System.arraycopy(chunk, 0, result, resultOffset, chunk.length);
+            resultOffset += chunk.length;
+        }
+        return result;
+    }
+
+    /**
+     * Decodes the given data buffer starting at offset till length, failing
+     * if decompressed output would exceed {@code maxOutputSize} bytes. Use to
+     * mitigate decompression bombs.
+     *
+     * @param data          source byte array
+     * @param offset        offset within {@code data}
+     * @param length        compressed length
+     * @param maxOutputSize cap on total decompressed bytes; {@code 0} for no cap
+     * @return decompressed bytes
+     * @throws IOException if input is corrupted, or output exceeds {@code maxOutputSize}
+     */
+    @Local
+    public static byte[] decompress(byte[] data, int offset, int length, int maxOutputSize) throws IOException {
+        DecoderJNI.Wrapper decoder = new DecoderJNI.Wrapper(length);
+        ArrayList<byte[]> output = new ArrayList<>();
+        int totalOutputSize = 0;
+        try {
+            decoder.getInputBuffer().put(data, offset, length);
+            decoder.push(length);
+            while (decoder.getStatus() != DecoderJNI.Status.DONE) {
+                switch (decoder.getStatus()) {
+                    case OK:
+                        decoder.push(0);
+                        break;
+
+                    case NEEDS_MORE_OUTPUT:
+                        ByteBuffer buffer = maxOutputSize > 0
+                                ? decoder.pull(Math.max(1, maxOutputSize - totalOutputSize))
+                                : decoder.pull();
+                        byte[] chunk = new byte[buffer.remaining()];
+                        buffer.get(chunk);
+                        output.add(chunk);
+                        totalOutputSize += chunk.length;
+                        if (maxOutputSize > 0 && totalOutputSize >= maxOutputSize
+                                && decoder.getStatus() == DecoderJNI.Status.NEEDS_MORE_OUTPUT) {
+                            throw new IOException("decompressed size exceeds maximum size " + maxOutputSize);
+                        }
+                        break;
+
+                    case NEEDS_MORE_INPUT:
+                        decoder.push(0);
                         if (decoder.getStatus() == DecoderJNI.Status.NEEDS_MORE_INPUT) {
                             throw new IOException("corrupted input");
                         }

--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/decoder/DecoderJNI.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/decoder/DecoderJNI.java
@@ -5,6 +5,7 @@
 */
 package com.aayushatharva.brotli4j.decoder;
 
+import com.aayushatharva.brotli4j.common.annotations.Local;
 import com.aayushatharva.brotli4j.common.annotations.Upstream;
 
 import java.io.IOException;
@@ -21,6 +22,8 @@ public class DecoderJNI {
 
     private static native ByteBuffer nativePull(long[] context);
 
+    private static native ByteBuffer nativePullBounded(long[] context, int maxBytes);
+
     private static native void nativeDestroy(long[] context);
 
     private static native boolean nativeAttachDictionary(long[] context, ByteBuffer dictionary);
@@ -36,10 +39,31 @@ public class DecoderJNI {
     public static class Wrapper {
         private final long[] context = new long[3];
         private final ByteBuffer inputBuffer;
+        private final int maxOutputChunkSize;
         private Status lastStatus = Status.NEEDS_MORE_INPUT;
         private boolean fresh = true;
 
         public Wrapper(int inputBufferSize) throws IOException {
+            this(inputBufferSize, 0);
+        }
+
+        /**
+         * Creates a Wrapper that caps every {@link #pull()} to at most
+         * {@code maxOutputChunkSize} bytes. A zero-or-negative value disables
+         * the cap (equivalent to the single-argument constructor).
+         *
+         * <p>Use this to bound peak memory when streaming potentially-malicious
+         * compressed input: each pull returns a {@link ByteBuffer} whose
+         * {@code remaining()} is at most {@code maxOutputChunkSize}, with
+         * remaining decoded output served by subsequent pulls.
+         *
+         * @param inputBufferSize     size of the decoder's input buffer
+         * @param maxOutputChunkSize  per-pull output cap in bytes; {@code 0} for no cap
+         * @throws IOException if native decoder initialization fails
+         */
+        @Local
+        public Wrapper(int inputBufferSize, int maxOutputChunkSize) throws IOException {
+            this.maxOutputChunkSize = Math.max(maxOutputChunkSize, 0);
             this.context[1] = inputBufferSize;
             this.inputBuffer = nativeCreate(this.context);
             if (this.context[0] == 0) {
@@ -113,7 +137,34 @@ public class DecoderJNI {
                 throw new IllegalStateException("pulling output from decoder in " + lastStatus + " state");
             }
             fresh = false;
-            ByteBuffer result = nativePull(context);
+            ByteBuffer result = (maxOutputChunkSize > 0)
+                    ? nativePullBounded(context, maxOutputChunkSize)
+                    : nativePull(context);
+            parseStatus();
+            return result;
+        }
+
+        /**
+         * Pulls decompressed output, returning at most {@code maxBytes} bytes.
+         * Use this to bound a single allocation when handling untrusted input;
+         * any remaining decoded output is served by subsequent pulls.
+         *
+         * @param maxBytes positive upper bound on the returned buffer size
+         * @return direct {@link ByteBuffer} with {@code remaining() <= maxBytes}
+         */
+        @Local
+        public ByteBuffer pull(int maxBytes) {
+            if (maxBytes <= 0) {
+                throw new IllegalArgumentException("maxBytes must be positive");
+            }
+            if (context[0] == 0) {
+                throw new IllegalStateException("brotli decoder is already destroyed");
+            }
+            if (lastStatus != Status.NEEDS_MORE_OUTPUT && !hasOutput()) {
+                throw new IllegalStateException("pulling output from decoder in " + lastStatus + " state");
+            }
+            fresh = false;
+            ByteBuffer result = nativePullBounded(context, maxBytes);
             parseStatus();
             return result;
         }

--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/decoder/Decoders.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/decoder/Decoders.java
@@ -66,8 +66,25 @@ public final class Decoders {
      */
     @Local
     public static DirectDecompress decompress(ByteBuf compressed, ByteBuf decompressed) throws IOException {
+        return decompress(compressed, decompressed, 0);
+    }
+
+    /**
+     * Decodes the given data buffer, failing if decompressed output would
+     * exceed {@code maxOutputSize} bytes. Use to mitigate decompression bombs.
+     *
+     * @param compressed    {@link ByteBuf} source
+     * @param decompressed  {@link ByteBuf} destination
+     * @param maxOutputSize cap on total decompressed bytes; {@code 0} for no cap
+     * @return {@link DirectDecompress} instance
+     * @throws IOException If output exceeds {@code maxOutputSize}
+     */
+    @Local
+    public static DirectDecompress decompress(ByteBuf compressed, ByteBuf decompressed, int maxOutputSize)
+            throws IOException {
         int compressedBytes = compressed.readableBytes();
         DecoderJNI.Wrapper decoder = new DecoderJNI.Wrapper(compressedBytes);
+        int totalOutputSize = 0;
         try {
             decoder.getInputBuffer().put(compressed.nioBuffer());
             decoder.push(compressedBytes);
@@ -78,8 +95,15 @@ public final class Decoders {
                         break;
 
                     case NEEDS_MORE_OUTPUT:
-                        ByteBuffer buffer = decoder.pull();
+                        ByteBuffer buffer = maxOutputSize > 0
+                                ? decoder.pull(Math.max(1, maxOutputSize - totalOutputSize))
+                                : decoder.pull();
+                        totalOutputSize += buffer.remaining();
                         decompressed.writeBytes(buffer);
+                        if (maxOutputSize > 0 && totalOutputSize >= maxOutputSize
+                                && decoder.getStatus() == DecoderJNI.Status.NEEDS_MORE_OUTPUT) {
+                            throw new IOException("decompressed size exceeds maximum size " + maxOutputSize);
+                        }
                         break;
 
                     case NEEDS_MORE_INPUT:

--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/decoder/DirectDecompress.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/decoder/DirectDecompress.java
@@ -50,6 +50,20 @@ public final class DirectDecompress {
     }
 
     /**
+     * Initiate direct decompression of data, failing if the decompressed
+     * output would exceed {@code maxOutputSize} bytes. Use to mitigate
+     * decompression bombs.
+     *
+     * @param compressedData Compressed data as Byte Array
+     * @param maxOutputSize  cap on total decompressed bytes; {@code 0} for no cap
+     * @return {@link DirectDecompress} Instance
+     * @throws IOException If output exceeds {@code maxOutputSize}, or other decoding error
+     */
+    public static DirectDecompress decompress(byte[] compressedData, int maxOutputSize) throws IOException {
+        return Decoder.decompress(compressedData, maxOutputSize);
+    }
+
+    /**
      * Get the result of decompression.
      *
      * @return {@link DecoderJNI.Status}

--- a/brotli4j/src/test/java/com/aayushatharva/brotli4j/decoder/DecoderTest.java
+++ b/brotli4j/src/test/java/com/aayushatharva/brotli4j/decoder/DecoderTest.java
@@ -17,14 +17,20 @@
 package com.aayushatharva.brotli4j.decoder;
 
 import com.aayushatharva.brotli4j.Brotli4jLoader;
+import com.aayushatharva.brotli4j.encoder.Encoder;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DecoderTest {
 
@@ -50,5 +56,95 @@ class DecoderTest {
         DirectDecompress directDecompress = Decoders.decompress(src, dst);
         assertEquals(DecoderJNI.Status.DONE, directDecompress.getResultStatus());
         assertEquals("Meow", new String(directDecompress.getDecompressedData()));
+    }
+
+    @Test
+    void boundedPullCapsEachChunk() throws IOException {
+        byte[] original = new byte[64 * 1024];
+        Arrays.fill(original, (byte) 'a');
+        byte[] compressed = Encoder.compress(original);
+
+        int cap = 4096;
+        DecoderJNI.Wrapper decoder = new DecoderJNI.Wrapper(compressed.length);
+        byte[] result = new byte[original.length];
+        int produced = 0;
+        try {
+            decoder.getInputBuffer().put(compressed);
+            decoder.push(compressed.length);
+            while (decoder.getStatus() != DecoderJNI.Status.DONE) {
+                switch (decoder.getStatus()) {
+                    case OK:
+                        decoder.push(0);
+                        break;
+                    case NEEDS_MORE_OUTPUT:
+                        ByteBuffer chunk = decoder.pull(cap);
+                        assertTrue(chunk.remaining() <= cap,
+                                "pull(int) returned " + chunk.remaining() + " > cap " + cap);
+                        int n = chunk.remaining();
+                        chunk.get(result, produced, n);
+                        produced += n;
+                        break;
+                    default:
+                        throw new IOException("unexpected status " + decoder.getStatus());
+                }
+            }
+        } finally {
+            decoder.destroy();
+        }
+        assertEquals(original.length, produced);
+        assertArrayEquals(original, result);
+    }
+
+    @Test
+    void wrapperConstructorAppliesStickyCap() throws IOException {
+        byte[] original = new byte[64 * 1024];
+        Arrays.fill(original, (byte) 'b');
+        byte[] compressed = Encoder.compress(original);
+
+        int cap = 8192;
+        DecoderJNI.Wrapper decoder = new DecoderJNI.Wrapper(compressed.length, cap);
+        try {
+            decoder.getInputBuffer().put(compressed);
+            decoder.push(compressed.length);
+            while (decoder.getStatus() != DecoderJNI.Status.DONE) {
+                switch (decoder.getStatus()) {
+                    case OK:
+                        decoder.push(0);
+                        break;
+                    case NEEDS_MORE_OUTPUT:
+                        ByteBuffer chunk = decoder.pull();
+                        assertTrue(chunk.remaining() <= cap,
+                                "sticky cap not applied: chunk=" + chunk.remaining());
+                        break;
+                    default:
+                        throw new IOException("unexpected status " + decoder.getStatus());
+                }
+            }
+        } finally {
+            decoder.destroy();
+        }
+    }
+
+    @Test
+    void decompressRejectsOutputExceedingMax() throws IOException {
+        byte[] original = new byte[64 * 1024];
+        Arrays.fill(original, (byte) 'c');
+        byte[] compressed = Encoder.compress(original);
+
+        IOException ex = assertThrows(IOException.class,
+                () -> Decoder.decompress(compressed, 1024));
+        assertTrue(ex.getMessage().contains("maximum size"),
+                "unexpected message: " + ex.getMessage());
+    }
+
+    @Test
+    void decompressWithMaxOutputAllowsExactFit() throws IOException {
+        byte[] original = new byte[8 * 1024];
+        Arrays.fill(original, (byte) 'd');
+        byte[] compressed = Encoder.compress(original);
+
+        DirectDecompress result = Decoder.decompress(compressed, original.length);
+        assertEquals(DecoderJNI.Status.DONE, result.getResultStatus());
+        assertArrayEquals(original, result.getDecompressedData());
     }
 }

--- a/natives/src/main/cpp/decoder_jni.cc
+++ b/natives/src/main/cpp/decoder_jni.cc
@@ -159,19 +159,16 @@ Java_com_aayushatharva_brotli4j_decoder_DecoderJNI_nativePush(
 }
 
 /**
- * Pull decompressed data from decoder.
+ * Pull decompressed data from decoder, optionally capped to max_bytes.
  *
- * @param ctx {in_cookie, out_status} tuple
- * @returns direct ByteBuffer; all the produced data MUST be consumed before
- *          any further invocation; null in case of error
+ * When max_bytes is 0, the underlying call returns all currently available
+ * output (up to brotli's internal default).
  */
-JNIEXPORT jobject JNICALL
-Java_com_aayushatharva_brotli4j_decoder_DecoderJNI_nativePull(
-    JNIEnv* env, jobject /*jobj*/, jlongArray ctx) {
+static jobject pullImpl(JNIEnv* env, jlongArray ctx, size_t max_bytes) {
   jlong context[3];
   env->GetLongArrayRegion(ctx, 0, 3, context);
   DecoderHandle* handle = getHandle(reinterpret_cast<void*>(context[0]));
-  size_t data_length = 0;
+  size_t data_length = max_bytes;
   const uint8_t* data = BrotliDecoderTakeOutput(handle->state, &data_length);
   bool hasMoreOutput = !!BrotliDecoderHasMoreOutput(handle->state);
   if (hasMoreOutput) {
@@ -186,6 +183,29 @@ Java_com_aayushatharva_brotli4j_decoder_DecoderJNI_nativePull(
   context[2] = hasMoreOutput ? 1 : 0;
   env->SetLongArrayRegion(ctx, 0, 3, context);
   return env->NewDirectByteBuffer(const_cast<uint8_t*>(data), data_length);
+}
+
+/**
+ * Pull decompressed data from decoder.
+ *
+ * @param ctx {in_cookie, out_status} tuple
+ * @returns direct ByteBuffer; all the produced data MUST be consumed before
+ *          any further invocation; null in case of error
+ */
+JNIEXPORT jobject JNICALL
+Java_com_aayushatharva_brotli4j_decoder_DecoderJNI_nativePull(
+    JNIEnv* env, jobject /*jobj*/, jlongArray ctx) {
+  return pullImpl(env, ctx, 0);
+}
+
+/**
+ * Pull decompressed data from decoder, capped to at most max_bytes per call.
+ */
+JNIEXPORT jobject JNICALL
+Java_com_aayushatharva_brotli4j_decoder_DecoderJNI_nativePullBounded(
+    JNIEnv* env, jobject /*jobj*/, jlongArray ctx, jint max_bytes) {
+  size_t cap = (max_bytes > 0) ? static_cast<size_t>(max_bytes) : 0;
+  return pullImpl(env, ctx, cap);
 }
 
 /**

--- a/natives/src/main/cpp/decoder_jni.h
+++ b/natives/src/main/cpp/decoder_jni.h
@@ -56,6 +56,22 @@ Java_com_aayushatharva_brotli4j_decoder_DecoderJNI_nativePull(
     JNIEnv* env, jobject /*jobj*/, jlongArray ctx);
 
 /**
+ * Pull decompressed data from decoder, capped to at most max_bytes per call.
+ *
+ * When max_bytes <= 0, behaves identically to nativePull (no cap).
+ *
+ * @param ctx {in_cookie, out_status} tuple
+ * @param max_bytes maximum number of bytes to return in this pull; <= 0 means
+ *                  no cap
+ * @returns direct ByteBuffer (size <= max_bytes when max_bytes > 0); all the
+ *          produced data MUST be consumed before any further invocation; null
+ *          in case of error
+ */
+JNIEXPORT jobject JNICALL
+Java_com_aayushatharva_brotli4j_decoder_DecoderJNI_nativePullBounded(
+    JNIEnv* env, jobject /*jobj*/, jlongArray ctx, jint max_bytes);
+
+/**
  * Releases all used resources.
  *
  * @param ctx {in_cookie} tuple

--- a/natives/src/main/cpp/decoder_jni_onload.cc
+++ b/natives/src/main/cpp/decoder_jni_onload.cc
@@ -22,6 +22,9 @@ static const JNINativeMethod kDecoderMethods[] = {
     {"nativePull", "([J)Ljava/nio/ByteBuffer;",
      reinterpret_cast<void*>(
          Java_com_aayushatharva_brotli4j_decoder_DecoderJNI_nativePull)},
+    {"nativePullBounded", "([JI)Ljava/nio/ByteBuffer;",
+     reinterpret_cast<void*>(
+         Java_com_aayushatharva_brotli4j_decoder_DecoderJNI_nativePullBounded)},
     {"nativeDestroy", "([J)V",
      reinterpret_cast<void*>(
          Java_com_aayushatharva_brotli4j_decoder_DecoderJNI_nativeDestroy)},


### PR DESCRIPTION
Motivation:

`DecoderJNI.Wrapper.pull()` may return large `ByteBuffer`s (up to ~16 MiB) with no way to limit size. This makes decoding untrusted input unsafe or forces extra buffering in user code.

Modification:

- Add per-call limit: `pull(int maxBytes)`
- Add persistent limit: `Wrapper(..., maxOutputChunkSize)`
- Add overloads in `Decoder`, `BrotliInputStream`, `BrotliDecoderChannel`
- Add `maxOutputSize` to `decompress(...)` APIs (fail with `IOException` if exceeded)
- Expose bounded output via JNI (`nativePullBounded`)

Result:

Callers can bound memory usage (per chunk or total) when decoding, without affecting existing usage.