### PR TITLE
Add workdir support for native binary extraction

### DIFF
--- a/brotli4j/src/main/java/com/aayushatharva/brotli4j/Brotli4jLoader.java
+++ b/brotli4j/src/main/java/com/aayushatharva/brotli4j/Brotli4jLoader.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright (c) 2020-2025, Aayush Atharva
+ *    Copyright (c) 2020-2026, Aayush Atharva
  *
  *    Brotli4j licenses this file to you under the
  *    Apache License, Version 2.0 (the "License");
@@ -20,6 +20,7 @@ import com.aayushatharva.brotli4j.common.annotations.Local;
 import com.aayushatharva.brotli4j.service.BrotliNativeProvider;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
@@ -53,7 +54,7 @@ public class Brotli4jLoader {
                     String platform = getPlatform();
                     String libPath = "/lib/" + platform + '/' + nativeLibName;
 
-                    File tempDir = new File(System.getProperty("java.io.tmpdir"), "com_aayushatharva_brotli4j_" + System.nanoTime());
+                    File tempDir = new File(resolveWorkdir(), "com_aayushatharva_brotli4j_" + System.nanoTime());
                     tempDir.mkdir();
                     tempDir.deleteOnExit();
 
@@ -113,6 +114,31 @@ public class Brotli4jLoader {
 
     public static Throwable getUnavailabilityCause() {
         return UNAVAILABILITY_CAUSE;
+    }
+
+    /**
+     * Resolves the directory used to extract the bundled native library.
+     *
+     * <p>If the {@code com.aayushatharva.brotli4j.native.workdir} system property is set,
+     * it is used as the extraction directory (created if it does not exist). Otherwise
+     * falls back to {@code java.io.tmpdir}. A custom workdir is useful when
+     * {@code java.io.tmpdir} is mounted {@code noexec}.
+     */
+    // Package-private for tests.
+    static File resolveWorkdir() throws IOException {
+        String workdir = System.getProperty("com.aayushatharva.brotli4j.native.workdir");
+        if (workdir != null) {
+            File dir = new File(workdir);
+            if (!dir.exists() && !dir.mkdirs()) {
+                throw new IOException("Custom native workdir mkdirs failed: " + workdir);
+            }
+            try {
+                return dir.getAbsoluteFile();
+            } catch (Exception ignored) {
+                return dir;
+            }
+        }
+        return new File(System.getProperty("java.io.tmpdir"));
     }
 
     private static String getPlatform() {

--- a/brotli4j/src/test/java/com/aayushatharva/brotli4j/Brotli4jLoaderWorkdirTest.java
+++ b/brotli4j/src/test/java/com/aayushatharva/brotli4j/Brotli4jLoaderWorkdirTest.java
@@ -1,0 +1,94 @@
+/*
+ *   Copyright (c) 2020-2026, Aayush Atharva
+ *
+ *   Brotli4j licenses this file to you under the
+ *   Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.aayushatharva.brotli4j;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class Brotli4jLoaderWorkdirTest {
+
+    private static final String WORKDIR_PROPERTY = "com.aayushatharva.brotli4j.native.workdir";
+
+    private String previousWorkdir;
+
+    @BeforeEach
+    void saveProperty() {
+        previousWorkdir = System.getProperty(WORKDIR_PROPERTY);
+        System.clearProperty(WORKDIR_PROPERTY);
+    }
+
+    @AfterEach
+    void restoreProperty() {
+        if (previousWorkdir == null) {
+            System.clearProperty(WORKDIR_PROPERTY);
+        } else {
+            System.setProperty(WORKDIR_PROPERTY, previousWorkdir);
+        }
+    }
+
+    @Test
+    void defaultsToJavaIoTmpdir() throws IOException {
+        File workdir = Brotli4jLoader.resolveWorkdir();
+        assertEquals(new File(System.getProperty("java.io.tmpdir")), workdir);
+    }
+
+    @Test
+    void usesExistingCustomWorkdir(@TempDir Path tempDir) throws IOException {
+        System.setProperty(WORKDIR_PROPERTY, tempDir.toString());
+
+        File workdir = Brotli4jLoader.resolveWorkdir();
+
+        assertTrue(workdir.isAbsolute());
+        assertEquals(tempDir.toFile().getAbsoluteFile(), workdir);
+        assertTrue(workdir.isDirectory());
+    }
+
+    @Test
+    void createsMissingWorkdir(@TempDir Path tempDir) throws IOException {
+        File missing = tempDir.resolve("nested/created/workdir").toFile();
+        assertFalse(missing.exists());
+        System.setProperty(WORKDIR_PROPERTY, missing.getPath());
+
+        File workdir = Brotli4jLoader.resolveWorkdir();
+
+        assertEquals(missing.getAbsoluteFile(), workdir);
+        assertTrue(workdir.isDirectory());
+    }
+
+    @Test
+    void throwsWhenWorkdirCannotBeCreated(@TempDir Path tempDir) throws IOException {
+        Path blocker = tempDir.resolve("blocker");
+        Files.createFile(blocker);
+        Path unreachable = blocker.resolve("subdir");
+        System.setProperty(WORKDIR_PROPERTY, unreachable.toString());
+
+        IOException error = assertThrows(IOException.class, Brotli4jLoader::resolveWorkdir);
+        assertTrue(error.getMessage().contains(unreachable.toString()));
+    }
+}


### PR DESCRIPTION
Motivation:
When the bundled native library is unpacked at runtime, `Brotli4jLoader` hardcodes `java.io.tmpdir` as the extraction directory. On hardened systems where `java.io.tmpdir` is mounted `noexec`, the extracted `.so`/`.dll`/`.dylib` cannot be loaded and `Brotli4jLoader` fails.

Modification:
Add a `com.aayushatharva.brotli4j.native.workdir` system property, mirroring Netty's `io.netty.native.workdir` semantics. When set, the loader extracts the native library into that directory (creating it via `mkdirs` if it does not exist, hard-failing with `IOException` if `mkdirs` fails). 

When unset, behaviour is unchanged and `java.io.tmpdir` is used. Added unit tests covering the default, existing-dir, missing-dir, and  `mkdirs`-failure paths.

Result:
Users on `noexec` `/tmp` can now point brotli4j at an executable directory via `-Dcom.aayushatharva.brotli4j.native.workdir=/path`
