### PR TITLE
Add BOM module

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -52,6 +52,19 @@ In your pull request, please include a detailed description of the changes you m
 </br>
 Once your pull request is submitted, it will be reviewed by one or more maintainers. They may ask for additional changes or provide feedback. Once your pull request is approved, it will be merged into the master branch.
 
+# Releasing
+When preparing a release, the project version must be bumped in lockstep across **every** `pom.xml` in the repository so all published artifacts (including the BOM) share the same version. Update the `<version>` (or `<parent><version>`) in:
+
+<li> root <code>pom.xml</code> </li>
+<li> <code>natives/pom.xml</code> and every <code>natives/&lt;arch&gt;/pom.xml</code> </li>
+<li> <code>brotli4j/pom.xml</code> </li>
+<li> <code>service/pom.xml</code> </li>
+<li> <code>bom/pom.xml</code> </li>
+<li> <code>all/pom.xml</code> </li>
+
+</br>
+Do not forget <code>bom/pom.xml</code>: if its version is not bumped, the published <code>brotli4j-bom</code> will reference a stale version and consumers importing it will resolve outdated artifacts.
+
 # Attribution
 We appreciate all contributions to Brotli4j and want to make sure that contributors are properly credited for their work. In your pull request, please add yourself to the list of contributors in the AUTHORS.md file. You can also add yourself to the list by opening a pull request that only modifies that file.
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,70 @@ For maven, the natives will
 </dependency>
 ```
 
+### BOM (Bill of Materials)
+
+If you depend on more than one Brotli4j artifact (for example, when explicitly pinning a specific
+native), import the BOM so every Brotli4j dependency stays on a single, consistent version. After
+importing the BOM, declare Brotli4j artifacts **without** a `<version>` and the BOM supplies it.
+
+> [!NOTE]
+> The BOM only manages versions. It is orthogonal to the Gradle `Brotli4JRule` metadata rule
+> (documented below), which automatically selects the correct native for your architecture. Use the
+> BOM when you reference individual `native-*` artifacts and want their versions managed centrally.
+
+#### Maven
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.aayushatharva.brotli4j</groupId>
+            <artifactId>brotli4j-bom</artifactId>
+            <version>1.23.0</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+
+<dependencies>
+    <dependency>
+        <groupId>com.aayushatharva.brotli4j</groupId>
+        <artifactId>brotli4j</artifactId>
+    </dependency>
+    <!-- Optional: pin a specific runtime native (version managed by the BOM) -->
+    <dependency>
+        <groupId>com.aayushatharva.brotli4j</groupId>
+        <artifactId>native-linux-x86_64</artifactId>
+        <scope>runtime</scope>
+    </dependency>
+</dependencies>
+```
+
+#### Gradle (Kotlin DSL)
+
+```kotlin
+dependencies {
+    implementation(platform("com.aayushatharva.brotli4j:brotli4j-bom:1.23.0"))
+
+    implementation("com.aayushatharva.brotli4j:brotli4j")
+    // Optional: pin a specific runtime native (version managed by the BOM)
+    runtimeOnly("com.aayushatharva.brotli4j:native-linux-x86_64")
+}
+```
+
+#### Gradle (Groovy DSL)
+
+```groovy
+dependencies {
+    implementation platform('com.aayushatharva.brotli4j:brotli4j-bom:1.23.0')
+
+    implementation 'com.aayushatharva.brotli4j:brotli4j'
+    // Optional: pin a specific runtime native (version managed by the BOM)
+    runtimeOnly 'com.aayushatharva.brotli4j:native-linux-x86_64'
+}
+```
+
 ### Gradle
 
 For gradle, some additional configuration must be added in order to allow gradle to resolve the correct native artifacts automatically,

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -30,70 +30,17 @@
     <packaging>pom</packaging>
 
     <name>Brotli4j/All</name>
-    <description>Builds all Brotli4j artifacts</description>
+    <description>Deprecated alias of brotli4j-bom. Builds all Brotli4j artifacts.</description>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>com.aayushatharva.brotli4j</groupId>
-                <artifactId>brotli4j</artifactId>
+                <artifactId>brotli4j-bom</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
-	    <dependency>
-                <groupId>com.aayushatharva.brotli4j</groupId>
-                <artifactId>service</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.aayushatharva.brotli4j</groupId>
-                <artifactId>native-linux-aarch64</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.aayushatharva.brotli4j</groupId>
-                <artifactId>native-linux-armv7</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.aayushatharva.brotli4j</groupId>
-                <artifactId>native-linux-x86_64</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.aayushatharva.brotli4j</groupId>
-                <artifactId>native-linux-s390x</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.aayushatharva.brotli4j</groupId>
-                <artifactId>native-linux-ppc64le</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.aayushatharva.brotli4j</groupId>
-                <artifactId>native-linux-riscv64</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.aayushatharva.brotli4j</groupId>
-                <artifactId>native-osx-aarch64</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.aayushatharva.brotli4j</groupId>
-                <artifactId>native-osx-x86_64</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.aayushatharva.brotli4j</groupId>
-                <artifactId>native-windows-x86_64</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-             <dependency>
-                <groupId>com.aayushatharva.brotli4j</groupId>
-                <artifactId>native-windows-aarch64</artifactId>
-                <version>${project.version}</version>
-            </dependency>           
         </dependencies>
     </dependencyManagement>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2020-2025, Aayush Atharva
+
+  Brotli4j licenses this file to you under the
+  Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.aayushatharva.brotli4j</groupId>
+        <artifactId>brotli4j-parent</artifactId>
+        <version>1.23.0</version>
+    </parent>
+
+    <artifactId>brotli4j-bom</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Brotli4j/BOM</name>
+    <description>Brotli4j Bill of Materials (BOM) for dependency version management</description>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>brotli4j</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>service</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-linux-x86_64</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-linux-aarch64</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-linux-armv7</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-linux-s390x</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-linux-ppc64le</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-linux-riscv64</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-osx-x86_64</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-osx-aarch64</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-windows-x86_64</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-windows-aarch64</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <module>natives</module>
         <module>brotli4j</module>
         <module>service</module>
+        <module>bom</module>
         <module>all</module>
     </modules>
 


### PR DESCRIPTION
Motivation:

Brotli4j publishes multiple related artifacts that must be used with matching versions. Consumers currently need to manage version alignment manually, increasing the risk of incompatibilities and adding unnecessary maintenance overhead during dependency upgrades.

Modification:

Introduce a Maven Bill of Materials (BOM) artifact that defines versions for all published Brotli4j modules. Consumers can import the BOM in their dependency management section and omit versions from individual Brotli4j dependencies, ensuring consistent version alignment across all modules.

Result:

Fixes #259
